### PR TITLE
Change 'ROS2' to 'ROS 2' and update docs links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 ## Introduction
 
-This repository contains source of training material for `ROS2 Foxy`. The topics covered are:
-- ROS2 basics
+This repository contains source of training material for `ROS 2 Foxy`. The topics covered are:
+- ROS 2 basics
     - Composed node, publish / subscribe, services, actions, parameters, launch system
     - Manged nodes, Quality of Service (QoS)
     - File system

--- a/slides/Basics/source/CLI.html
+++ b/slides/Basics/source/CLI.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>ROS2 CLI basics</title>
+    <title>ROS 2 CLI basics</title>
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="../../common/css/rostraining_slides.css">
   </head>
@@ -37,11 +37,11 @@ name: main_title
  # 1. Installation and sourcing
 ---
 
-## 1.1 Installing and Sourcing ROS2
+## 1.1 Installing and Sourcing ROS 2
 * Two types of installation - [Binary](https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Install-Debians/) (recommended) or [Source](https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/). 
-* Live USB has ROS2 Foxy Binary - Verify :   
+* Live USB has ROS 2 Foxy Binary - Verify :   
  `ll /opt/ros/foxy`. 
-* Source ROS2 to use commands, libraries, packages etc..:   
+* Source ROS 2 to use commands, libraries, packages etc..:   
 `source /opt/ros/foxy/setup.bash`   
 * Source your local workspace as needed (which source ROS as well):   
 `source /path/to/ws/install/local_setup.bash`
@@ -56,7 +56,7 @@ instead of
 `source /opt/ros/foxy/setup.bash`  (or any command you wish)
 * See cheat sheet for syntax.
 
-.center[!!ADVICE!!: Source ros2 manually everytime on Day 1 to get used to the concept. Use aliases from Day 2.]
+.center[!!ADVICE!!: Source ROS 2 manually everytime on Day 1 to get used to the concept. Use aliases from Day 2.]
 
 ---
 
@@ -65,13 +65,13 @@ instead of
 * Environment variable 
 * Unique identifier number for each machine
 * Physically separates network
-* Stop ROS2 node interference
+* Stop ROS 2 node interference
 * Set and forget : `echo "export ROS_DOMAIN_ID=<your_id>" >> ~/.bashrc`
 
 
 .center[100% discount sale! - Ask for your very own domain ID today!!]
 
-### Building ROS2 (Recap)
+### Building ROS 2 (Recap)
 
 * `colcon build --symlink-install`
 
@@ -88,7 +88,7 @@ name: main_title
 
 We only explore default packages that come with the binary for simplicity.
 
-* All ROS2 commands follow this syntax :
+* All ROS 2 commands follow this syntax :
 `ros2 <main_command> <sub_command> <<arguments>>`   
 
 * Examples :  
@@ -96,7 +96,7 @@ We only explore default packages that come with the binary for simplicity.
 `ros2 pkg executables`
 
 Use tab completion to either complete a command, or to see a list of available options. 
-* Example: `ros2 ` *tab* *tab* - List all ROS2 commands.
+* Example: `ros2 ` *tab* *tab* - List all ROS 2 commands.
 * `ros2 pkg ` *tab* *tab* - List of sub-commands for `pkg`.   
 * `-h` at almost any point to get a brief help description. 
 `ros2 -h`   
@@ -115,12 +115,12 @@ name: main_title
 
 The most basic example of ROS - a *Publisher/Subscriber* pair 
 
-* Remember to source ROS2 
+* Remember to source ROS 2 
 * Command `run` to run an executable within a package (C++ compiled object/Python script):    
 
 `ros2 run <package_name> <executable_name> <<optional_command_line_arguments>>`   
 
-* Try the example publisher node packaged with ROS2. 
+* Try the example publisher node packaged with ROS 2. 
 * We first need to find out what the name of the package is.   
 * Run the package listing command  with a filter:    
 `ros2 pkg list | grep demo`   
@@ -242,7 +242,7 @@ name: main_title
 * Useful for longer tasks that need a feedback & involves an action server and an action client.
 * Interface has 3 parts - goal, feedback and result.
 * Typical sequence - Publish a goal, observe feedback & receive result  when execution is completed/aborted
-* Use the `ros2 action [..]` commands to interact. (New in ROS2)  
+* Use the `ros2 action [..]` commands to interact. (New in ROS 2)  
     * Similar to `ros2 topic [..]`
 
 
@@ -253,7 +253,7 @@ name: main_title
 * Key-value pairs to store runtime configuration information.
     * Ex: laser scan field, camera calibration, navigation obstacle layer thickness etc...
 * Parameters are stored per each node and can be accessed via services
-    * As opposed to ROS1 which had a dedicated parameter server managed by rosmaster.
+    * As opposed to ROS 1 which had a dedicated parameter server managed by rosmaster.
 * Use `ros2 param [..]` commands to interact from the CLI.
 
 ###### More in workshop
@@ -274,7 +274,7 @@ name: main_title
     * Topic publisher/listener/type viewer, 
     * Image view, 
     * Plot  etc....
-* Similar to ROS1, but few plugins still missing
+* Similar to ROS 1, but few plugins still missing
 * `rqt &` to launch default main window (`&` ->detached process)
 or 
 `ros2 run rqt_<plugin> rqt_<plugin>` to launch a specific plugin
@@ -288,7 +288,7 @@ or
 ##### The doctor is in the house!
 
 * Identify issues in the system (similar to roswtf, can use wtf as an alias)
-* Analyse ROS2 installation as well as running systems, show reports
+* Analyse ROS 2 installation as well as running systems, show reports
 * `ros2 doctor` - Shows warnings and errors about the current state
     * Dangling topics, incorrect configurations, missing system files etc...
 * `ros2 doctor -r` - Full technical report of the installation
@@ -298,7 +298,7 @@ or
 
 ## 6.3 Tools - ros2bag
 
-* Same function and similar API as rosbag from ROS1
+* Same function and similar API as rosbag from ROS 1
     * Now installed as part of >Foxy core
 * Record the messages being published on topics for a duration into a file. Replay later with nearly the same time characteristics.
 * Stored as *.db3 + metadata.yaml* instead of a single *.bag file.
@@ -307,14 +307,14 @@ or
 
 ## 6.4 Tools - ros1_bridge
 
-* A "dual homed" package - simultaneously ROS1 AND ROS2.
-* ROS1 <=topics/services=> `ros1_bridge` <=topics/services=> ROS2
+* A "dual homed" package - simultaneously ROS 1 AND ROS 2.
+* ROS 1 <=topics/services=> `ros1_bridge` <=topics/services=> ROS 2
 * Binary installation supports default msg/srv types, source installation can be extended with custom types.
 
 ```
-Shell 1 $  Source ROS1, Run ROS1 stuff
-Shell 2 $  Source ROS1, Source ROS2, Run bridge
-Shell 3 $  Source ROS2, Run ROS2 stuff
+Shell 1 $  Source ROS 1, Run ROS 1 stuff
+Shell 2 $  Source ROS 1, Source ROS 2, Run bridge
+Shell 3 $  Source ROS 2, Run ROS 2 stuff
 ```
 >                                        MAGIC!
 

--- a/slides/Basics/source/CLI.html
+++ b/slides/Basics/source/CLI.html
@@ -38,7 +38,7 @@ name: main_title
 ---
 
 ## 1.1 Installing and Sourcing ROS 2
-* Two types of installation - [Binary](https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Install-Debians/) (recommended) or [Source](https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/). 
+* Two types of installation - [Binary](https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html) (recommended) or [Source](https://docs.ros.org/en/foxy/Installation/Ubuntu-Development-Setup.html). 
 * Live USB has ROS 2 Foxy Binary - Verify :   
  `ll /opt/ros/foxy`. 
 * Source ROS 2 to use commands, libraries, packages etc..:   

--- a/slides/Basics/source/Cheat_sheet_concise.md
+++ b/slides/Basics/source/Cheat_sheet_concise.md
@@ -3,17 +3,17 @@
 ###### ROS 2 package installation syntax:   
 `sudo apt install ros-foxy-<pkg_name>`
 
-###### Basic ROS2 command structure:   
+###### Basic ROS 2 command structure:   
 `ros2 <main_command> <sub_command> [--options] <list_of_arguments>`    
 
 Remember, you can use double `[tab][tab]` completion to find list of available options and `-h` to get some help text at any point.
 
-Every ROS2 command and sub-command has a list of options that you can use to modify its behavior. The list of options can be seen with `-h` and included as desired.   
+Every ROS 2 command and sub-command has a list of options that you can use to modify its behavior. The list of options can be seen with `-h` and included as desired.   
 
 You can use `| grep <string>` to filter results using a string.   
 
 ## Commonly used commands
-Sourcing ROS2:   
+Sourcing ROS 2:   
 * `source /opt/ros/foxy/setup.bash`
 
 Alias:

--- a/slides/Basics/source/Core_concepts.html
+++ b/slides/Basics/source/Core_concepts.html
@@ -20,7 +20,7 @@ class: center, middle
 
 <h1> 
   <center>  
-    ROS2 Foundation 
+    ROS 2 Foundation 
   </center> 
 </h1> 
 <h3> 
@@ -35,12 +35,12 @@ class: center, middle
 - #### ROS computation graph
 - #### What is a node?  
 - #### Node composition 
-- #### ROS2 topics and messages
-- #### ROS2 Executor 
-- #### ROS2 Services
-- #### ROS2 Actions
-- #### ROS2 Params
-- #### ROS2 Launch files
+- #### ROS 2 topics and messages
+- #### ROS 2 Executor 
+- #### ROS 2 Services
+- #### ROS 2 Actions
+- #### ROS 2 Params
+- #### ROS 2 Launch files
  
 
 
@@ -91,7 +91,7 @@ class: center, middle
 ---
 
 ## Automatic discovery
-### ROS1 Node communication
+### ROS 1 Node communication
 <div>
   <center>
     <img src="../static/singlepointfailure.png" width="800px">
@@ -100,7 +100,7 @@ class: center, middle
 
 ---
 
-## ROS1 vs ROS2 
+## ROS 1 vs ROS 2 
 ### Node structure
 
 <center>
@@ -111,7 +111,7 @@ class: center, middle
 ---
 
 ## Automatic discovery
-### ROS2 Node communication
+### ROS 2 Node communication
 
 .cols[
   .fifty[ <img src="../static/ros2_discovery.png" width="500px">  ]
@@ -135,8 +135,8 @@ class: center, middle
 
 ---
 
-## ROS2-Unified API
-### ROS2 Client libraries
+## ROS 2-Unified API
+### ROS 2 Client libraries
 
 .cols[
 .fifty[<div>
@@ -225,7 +225,7 @@ Defers process layout decisions to deploy-time
 - Distributed parameter system 
 ---
 
-## ROS2 Topics 
+## ROS 2 Topics 
 - Asynchronous communication 
 - Multiple concurrent publishers and subscribers for one topic
 - A single node can publish and subscribe to multiple topics
@@ -240,7 +240,7 @@ Defers process layout decisions to deploy-time
 
 ---
 
-## ROS2 Messages
+## ROS 2 Messages
 
 - data structure to exchange information between components  
 - `*.msg` are simple text files with field type and name   
@@ -265,7 +265,7 @@ Defers process layout decisions to deploy-time
 
 ---
 
-## ROS2 Executor
+## ROS 2 Executor
 
 ### Coordinates order and timing to execute available communication tasks
 
@@ -287,7 +287,7 @@ Defers process layout decisions to deploy-time
 ]
  
 ---
-## ROS2 Executor
+## ROS 2 Executor
 
 **Default executor**
 <pre><code class="language-ruby">
@@ -313,7 +313,7 @@ Defers process layout decisions to deploy-time
 
 ---
 
-## ROS2 Services
+## ROS 2 Services
 -   Services are based on a call and response model 
 -   Similar to remote procedural calls that terminates quickly
     -   Example: spawning a robot into an environment
@@ -359,7 +359,7 @@ Defers process layout decisions to deploy-time
 
 ---
 
-## ROS2 Actions
+## ROS 2 Actions
 
 -   Used for tasks that  
     - <b>Longer execution time</b>
@@ -392,7 +392,7 @@ Defers process layout decisions to deploy-time
 
 ---
 
-## ROS2 Actions
+## ROS 2 Actions
 ### Data structure for Actions
 
 -   Defined by a set of messages: Goal, Result and Feedback.
@@ -454,7 +454,7 @@ class: center
 
 ---
 
-## ROS2 Params
+## ROS 2 Params
 
 <div>
   <center>
@@ -465,11 +465,11 @@ class: center
 
 ---
 
-## ROS2 Params - 1
+## ROS 2 Params - 1
 
 - Used to externally configure the nodes at run-time and during run-time, without having to recompile the code for the node.
-- These parameters can be dynamically reconfigured using ROS2 services.
-- **Note**: ROS2 uses a decentralized parameter system.
+- These parameters can be dynamically reconfigured using ROS 2 services.
+- **Note**: ROS 2 uses a decentralized parameter system.
 
 <pre><code class="language-ruby">
 def __init__(self):
@@ -482,7 +482,7 @@ def __init__(self):
     self.get_logger().info("str: %s, int: %s" % (str(param_str.value), str(param_int.value)))
 </code></pre>
 
-#### Setting the ros2 params in command line.
+#### Setting the ROS 2 params in command line.
 <pre><code class="language-sh">
   ros2 run ros2_tutorials test_params_rclpy --ros-args -p my_str:="Hello world" -p my_int:=5
 </code>
@@ -490,8 +490,8 @@ def __init__(self):
 
 ---
 
-## ROS2 Params - 2
-### YAML for ROS2 params
+## ROS 2 Params - 2
+### YAML for ROS 2 params
 
 - Managing parameters when number of params increases becomes complex.
 - Adding them in command line is not an option 
@@ -508,7 +508,7 @@ def __init__(self):
 
 ---
 
-## ROS2 Params - 3
+## ROS 2 Params - 3
 ### Loading YAML config to Node
 
 <pre><code class="language-yaml">
@@ -533,7 +533,7 @@ ros2 run pkg_name node_name --ros-args --params-file .~/locate_pkg/config/params
 
 ---
 
-## ROS2 Params - 4
+## ROS 2 Params - 4
 ###  From launch file
 <pre><code class="language-python">
   def generate_launch_description():
@@ -556,7 +556,7 @@ ros2 run pkg_name node_name --ros-args --params-file .~/locate_pkg/config/params
 </pre>
 ---
 
-## ROS2 Params - 5
+## ROS 2 Params - 5
 ###  For a Python package, in “setup.py”:
 <pre><code class="language-python">
   ...
@@ -570,7 +570,7 @@ ros2 run pkg_name node_name --ros-args --params-file .~/locate_pkg/config/params
 ...
 </code>
 </pre>
-[References for ROS2 Params](https://docs.ros.org/en/foxy/Concepts/About-ROS-2-Parameters.html)
+[References for ROS 2 Params](https://docs.ros.org/en/foxy/Concepts/About-ROS-2-Parameters.html)
 
 ---
 
@@ -600,8 +600,8 @@ ros2 run pkg_name node_name --ros-args --params-file .~/locate_pkg/config/params
 ## Creating Launch files
 ### Location of launch file
 
--   ROS2 Launch files are coded in python
--   They are executed by ROS2 CLI tool, `ros2 launch` 
+-   ROS 2 Launch files are coded in python
+-   They are executed by ROS 2 CLI tool, `ros2 launch` 
 -   Create a `launch` directory inside your package as given below
 -   Create a launch file with `<launch_filename>.py`inside `launch` directory
 <div>

--- a/slides/Basics/source/Extended_Concepts.html
+++ b/slides/Basics/source/Extended_Concepts.html
@@ -222,7 +222,7 @@ Examples:
 
 Try the ROS 2 Managed Nodes [demo](https://github.com/ros2/demos/tree/master/lifecycle) to get a better understanding.
 
-Try the ROS 2 QoS [tutorials](https://index.ros.org/doc/ros2/Tutorials/Quality-of-Service/) to get a better understanding.
+Try the ROS 2 QoS [tutorials](https://docs.ros.org/en/foxy/Tutorials/Quality-of-Service.html) to get a better understanding.
 
 
 

--- a/slides/Basics/source/Extended_Concepts.html
+++ b/slides/Basics/source/Extended_Concepts.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>ROS2 Extended Concepts</title>
+    <title>ROS 2 Extended Concepts</title>
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="../../common/css/rostraining_slides.css">
   </head>
@@ -16,7 +16,7 @@ layout: true
 class: center, middle
 name: main_title
 
-# ROS2 EXTENDED CONCEPTS
+# ROS 2 EXTENDED CONCEPTS
 
 ---
 
@@ -36,7 +36,7 @@ name: main_title
 
 ## 1. Managed Nodes
 
-* Common complaint in ROS1 - no way to control lifecycle of nodes. 
+* Common complaint in ROS 1 - no way to control lifecycle of nodes. 
   * Ex: Sensor reader starts before sensor driver!
 * ROS 2 solution - *Managed Nodes* with detailed lifecycle management
   * CPP implemented, Python pending
@@ -128,7 +128,7 @@ Meaningfully implementing the callback functions avoids malformed nodes.
 
 ## 1.5 LC Management in Launch Files
 
-ROS2 Python Launch files offer some LC API:
+ROS 2 Python Launch files offer some LC API:
 * `launch_ros.actions.LifecycleNode(..)` defines a LC node
 * `launch_ros.event_handlers.OnStateTransition(..)` performs an action when a LC node transitions from one state to another
 * `launch.actions.EmitEvent(..)` selects the desired event to trigger
@@ -172,7 +172,7 @@ which defines the quality of communication between these entities.
 | 4   | Deadline | Maximum acceptable time between messages on a topic. | duration(rmw_time_t/rclcpp::Duration)|
 | 5   | Lifespan | Maximum time that a message can sit in a publisher's out buffer. | duration(rmw_time_t/rclcpp::Duration) |
 | 6   | Liveliness | Heartbeat frequency. | duration(rmw_time_t/rclcpp::Duration) |
-| 7   | avoid_ros _namespace_conventions | Circumvent ROS2 specific naming conventions like "rt_". Suitable for native DDS communication. | True/False |
+| 7   | avoid_ros _namespace_conventions | Circumvent ROS 2 specific naming conventions like "rt_". Suitable for native DDS communication. | True/False |
 
 ---
 
@@ -180,11 +180,11 @@ which defines the quality of communication between these entities.
 
 * Combination of policies. Easier to select a profile instead of worrying about individual policies.
 * Some default profiles already available (Ex C++: [qos_profiles.h](https://github.com/ros2/rmw/blob/master/rmw/include/rmw/qos_profiles.h)):
-  * **Default** : Applied by default if not specified. Mimic ROS1.   
+  * **Default** : Applied by default if not specified. Mimic ROS 1.   
    *keep_last(10),reliable(),volatile()...*
   * **Services** : Typically services should be reliable. Volatile to avoid outdated requests.   
    *keep_last(10),reliable(),volatile()...*
-  * **Parameters** : ROS2 parameters are accessed via services. Similar profile, but longer depth to retain more parameters in buffer.   
+  * **Parameters** : ROS 2 parameters are accessed via services. Similar profile, but longer depth to retain more parameters in buffer.   
    *keep_last(1000),reliable(),volatile()...*
   * **Sensors** : Sensor data needs to have minimum latency to remain relevant, at the cost of losing some samples.    
    *keep_last(5),best_effort(),volatile()...*
@@ -220,9 +220,9 @@ Examples:
 
 ## Further reading
 
-Try the ROS2 Managed Nodes [demo](https://github.com/ros2/demos/tree/master/lifecycle) to get a better understanding.
+Try the ROS 2 Managed Nodes [demo](https://github.com/ros2/demos/tree/master/lifecycle) to get a better understanding.
 
-Try the ROS2 QoS [tutorials](https://index.ros.org/doc/ros2/Tutorials/Quality-of-Service/) to get a better understanding.
+Try the ROS 2 QoS [tutorials](https://index.ros.org/doc/ros2/Tutorials/Quality-of-Service/) to get a better understanding.
 
 
 

--- a/slides/Basics/source/filesystem.html
+++ b/slides/Basics/source/filesystem.html
@@ -128,7 +128,7 @@ name: main_title
 -->
 
 <!-- setup.cfg  ros2 run can find them
-https://index.ros.org/doc/ros2/Tutorials/Creating-A-ROS2-Package/ -->
+https://docs.ros.org/en/foxy/Tutorials/Creating-Your-First-ROS2-Package.html -->
 
 ---
 
@@ -393,7 +393,7 @@ CMakeLists.txt Example:
 ---
 
 <!--
-ament_cmake User Documentation https://index.ros.org/doc/ros2/Tutorials/Ament-CMake-Documentation/-->
+ament_cmake User Documentation https://docs.ros.org/en/foxy/Guides/Ament-CMake-Documentation.html -->
 
 
 ### Colcon - a universal build tool
@@ -442,7 +442,7 @@ Lint tools : Static checking of Python or C++ source code for errors and standar
  <test_depend>ament_pep257</test_depend>
  ```
 <!--https://github.com/ament/ament_lint 
-https://index.ros.org/doc/ros2/Tutorials/Ament-CMake-Documentation/#linting -->
+https://docs.ros.org/en/foxy/Guides/Ament-CMake-Documentation.html#linting -->
 
 - For CMake package
   - package.xml
@@ -654,7 +654,7 @@ $ ros2 run examples_rclpy_minimal_publisher publisher_member_function
     "node name.py"
     ``` -->
 <!--The setup.py file contains the same description, maintainer and license fields as package.xml
-https://index.ros.org/doc/ros2/Tutorials/Creating-A-ROS2-Package/#what-is-a-ros-2-package -->
+https://docs.ros.org/en/foxy/Tutorials/Creating-Your-First-ROS2-Package.html#what-is-a-ros-2-package -->
 
 ---
 

--- a/slides/Basics/source/filesystem.html
+++ b/slides/Basics/source/filesystem.html
@@ -22,7 +22,7 @@ class: center, middle
 name: main_title
 
 # ROS-I Academy Training
-### ROS2 Filesystem
+### ROS 2 Filesystem
 
 ---
 
@@ -43,9 +43,9 @@ name: main_title
 
 ## Package
 
-- The software in ROS2 is organized into **packages**
+- The software in ROS 2 is organized into **packages**
 
-- The smallest build part in ROS2
+- The smallest build part in ROS 2
 
 - Dedicated to one functionality, e.g. :
   - Hardware driver

--- a/slides/Manipulation/source/moveit.html
+++ b/slides/Manipulation/source/moveit.html
@@ -43,7 +43,7 @@ controllers through common interfaces
 
 ---
 
-## Why ROS2 vs ROS1?  
+## Why ROS 2 vs ROS 1?  
 
 - Realtime capabilities now available
 - Designed for production - same support for R&D
@@ -53,18 +53,18 @@ controllers through common interfaces
 
 ## Milestones
 
-- M1: Straight port to ROS2
-    - Fully migrate existing packages to ROS2
-    - Leverage ROS2 features: build (ament), middleware, logging, parameters
+- M1: Straight port to ROS 2
+    - Fully migrate existing packages to ROS 2
+    - Leverage ROS 2 features: build (ament), middleware, logging, parameters
 
 - M2: Real-time support 
     - Reactive, closed-loop control to sensor input
     - Hybrid planning (global and local)
     - Zero-memory copy integration to controllers  
 
-- M3: Fully leverage ROS2
+- M3: Fully leverage ROS 2
     - Lifecycle management of MoveIt nodes
-    - Leverage ROS2 component nodes
+    - Leverage ROS 2 component nodes
 ---
 
 ## Real-time capabilities 
@@ -95,7 +95,7 @@ Direct access to core MoveIt components
 ## Architecture
 (Milestone 3)  
 
-Leverage ROS2 component nodes for better performance
+Leverage ROS 2 component nodes for better performance
 
 ![components width:200](../static/components.png)
 ---
@@ -194,7 +194,7 @@ http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/urdf_srdf/urdf_srdf_tu
 
 ```cpp
 // \brief load the robot model,
-//        configure the planning pipeline from ROS2 parameters and
+//        configure the planning pipeline from ROS 2 parameters and
 //        initialize defaults  
 moveit_cpp_ = std::make_shared<moveit::planning_interface::MoveItCpp>(node_);
 

--- a/slides/Navigation/source/Basics.html
+++ b/slides/Navigation/source/Basics.html
@@ -173,11 +173,11 @@ Ex: [robot_localization package](https://github.com/cra-ros-pkg/robot_localizati
 
 ---
 
-## Localization in ROS2 - AMCL
+## Localization in ROS 2 - AMCL
 
 .cols[
   .sixty[
-  Implementation of localization in [Navigation 2](https://github.com/ros-planning/navigation2), port of [ROS1 AMCL](http://wiki.ros.org/amcl)
+  Implementation of localization in [Navigation 2](https://github.com/ros-planning/navigation2), port of [ROS 1 AMCL](http://wiki.ros.org/amcl)
 
   Adaptive Monte Carlo Localization with:
 

--- a/slides/Navigation/source/Navigation2.html
+++ b/slides/Navigation/source/Navigation2.html
@@ -515,7 +515,7 @@ Define the recovery actions that the robot can perform.
 
 ## Navigation 2 - Life Cycle Manager
 
-The nodes within NAV2 are managed by the LifeCycle Manager of ROS2 (see Basic Slides).
+The nodes within NAV2 are managed by the LifeCycle Manager of ROS 2 (see Basic Slides).
 
 <img src="../static/lifecycle_manager.png" alt="lifecycle_manager" style="width:700px" class="image-center"/>
 

--- a/slides/Navigation/source/SLAM.html
+++ b/slides/Navigation/source/SLAM.html
@@ -76,11 +76,11 @@ name: main_title
 ## Mapping - SLAM
 ### ROS 2 tools
 
-SLAM for ROS2 unfortunately does not have a golden standard yet. Some contenders are:
+SLAM for ROS 2 unfortunately does not have a golden standard yet. Some contenders are:
 
 * LaMa (2D) - IRIS Labs - New, arguably better, strong contender
 
-* Cartographer (2D/3D) - Google - Ported from ROS1, used often, but not maintained
+* Cartographer (2D/3D) - Google - Ported from ROS 1, used often, but not maintained
 
 * SLAM Toolbox (2D) - Steve Macenski - Currently shipped with Navigation2, needs support.
 [Help if you can!](https://discourse.ros.org/t/slam-toolbox-the-new-default-slam-implementation-for-ros2/12369)

--- a/slides/Navigation/source/TF.html
+++ b/slides/Navigation/source/TF.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>ROS2 TF2</title>
+    <title>ROS 2 TF2</title>
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="../../common/css/rostraining_slides.css">
   </head>
@@ -17,17 +17,17 @@ layout: true
 class: center, middle
 name: main_title
 
-# TF2 - TRANSFORMS IN ROS2
+# TF2 - TRANSFORMS IN ROS 2
 
 ---
 
 ## TF2 - Overview
 
-* TF2 is the second generation of the TF (TransForm) library. In truth, TF in ROS1 currently calls TF2 under the hood. ROS2 uses exclusively TF2.   
+* TF2 is the second generation of the TF (TransForm) library. In truth, TF in ROS 1 currently calls TF2 under the hood. ROS 2 uses exclusively TF2.   
 
 * TF2 keeps track of all the coordinate frames in a tree structure.
 
-* Like most things in ROS2, the TF2 API is still under development, but basic features are already usable.
+* Like most things in ROS 2, the TF2 API is still under development, but basic features are already usable.
 
 * TF2 vs TF - Faster, more efficient, new features and easier to extend.
 

--- a/workshop/source/_source/basics/ROS2-Filesystem.md
+++ b/workshop/source/_source/basics/ROS2-Filesystem.md
@@ -1,8 +1,8 @@
-# ROS2 File System
+# ROS 2 File System
 
 ## 1. Introduction
 
-During this tutorial, you will learn how to navigate through your ROS2 system. In addition, you will start your first ROS2 nodes and create your own ROS workspace for further tutorials. You can use the given links in the documentation for further information.
+During this tutorial, you will learn how to navigate through your ROS 2 system. In addition, you will start your first ROS 2 nodes and create your own ROS workspace for further tutorials. You can use the given links in the documentation for further information.
 
 - Lines beginning with $ are terminal commands.
 
@@ -14,7 +14,7 @@ During this tutorial, you will learn how to navigate through your ROS2 system. I
 
 ## 2. ROS File System
 
-Before starting make sure that your system is aware of the latest ROS2 packages:
+Before starting make sure that your system is aware of the latest ROS 2 packages:
 
 ```bash
 $ sudo apt update
@@ -25,7 +25,7 @@ If you just installed **rosdep**, please run this commands first:
 $ sudo rosdep init
 ```
 
-The ROS2 File System consists of ROS2 packages – the smallest build part in ROS2.
+The ROS 2 File System consists of ROS 2 packages – the smallest build part in ROS 2.
 
 Usually, a ROS File System consists of hundreds of different packages. To navigate efficiently through your ROS system, ROS provides different management tools. The most common tools are described in the example of the ROS package turtlesim.
 
@@ -45,7 +45,7 @@ in your workspace
 $ source install/setup.bash
 ```
 ## 3. Workspace
-Colcon is a build tool for ROS2. A  workspace is a folder, where you can modify, build, and install packages. It is the place to create your packages and nodes or modify existing ones to fit your application. In the further tutorials, you will
+Colcon is a build tool for ROS 2. A  workspace is a folder, where you can modify, build, and install packages. It is the place to create your packages and nodes or modify existing ones to fit your application. In the further tutorials, you will
 work in your workspace.
 
 * Create workspace:
@@ -56,7 +56,7 @@ work in your workspace.
 
 ## 4. ROS packages
 
-Two types of ROS2 packages exist: binary packages and build-from-source packages.
+Two types of ROS 2 packages exist: binary packages and build-from-source packages.
 
 ROS binary packages are in Ubuntu provided as debian packages, which can be managed via apt commands. 
 
@@ -81,7 +81,7 @@ ROS binary packages are in Ubuntu provided as debian packages, which can be mana
     ```
     `# ros2 pkg executables <package_name>`
 
-Build-from-source packages can be divided into packages provided by ROS2 and your developments. Both have to be placed into the src folder of a ROS2 workspace.
+Build-from-source packages can be divided into packages provided by ROS 2 and your developments. Both have to be placed into the src folder of a ROS 2 workspace.
 
 
 
@@ -94,7 +94,7 @@ Build-from-source packages can be divided into packages provided by ROS2 and you
     ```
     `# git clone -b <branch> <address>`
 
-    Notice the “Branch” drop-down list to the left above the directories list. When you clone this repo, add the -b argument followed by the branch that corresponds with your ROS2 distro.
+    Notice the “Branch” drop-down list to the left above the directories list. When you clone this repo, add the -b argument followed by the branch that corresponds with your ROS 2 distro.
     
     To see the packages inside ros_tutorials, enter the command:
     ```bash
@@ -102,7 +102,7 @@ Build-from-source packages can be divided into packages provided by ROS2 and you
     ```
     You will find you have four packages: `roscpp_tutorials  rospy_tutorials  ros_tutorials  turtlesim` 
 
-    Only **turtlesim** is ROS2 package
+    Only **turtlesim** is ROS 2 package
 
 * Resolve dependencies: 
 
@@ -130,7 +130,7 @@ Build-from-source packages can be divided into packages provided by ROS2 and you
 * Source the overlay
     When you build this workspace, your main ROS 2 environment is the “underlay”. Now you can source overlay "on the top of" "underlay".
     
-    ***Hint***: If you open a new terminal, set up ROS2 environment first. 
+    ***Hint***: If you open a new terminal, set up ROS 2 environment first. 
     ```bash
     you can start a new terminal window by
     ctl + alt +t
@@ -164,7 +164,7 @@ A ROS node is an executable in the ROS environment. A node is always a part of a
 
     You can control the turtle with the arrow keys of the keyboard, if the current terminal running the turtle_teleop_node is selected.
 
-The two nodes turtlesim_node and turtle_teleop_key are currently active on your ROS2 system. Since systems that are more complex will consist of many nodes, ROS offers introspection tools to display information about active nodes.
+The two nodes turtlesim_node and turtle_teleop_key are currently active on your ROS 2 system. Since systems that are more complex will consist of many nodes, ROS offers introspection tools to display information about active nodes.
 * Display all active nodes:
     ```bash
     $ ros2 node list

--- a/workshop/source/_source/basics/ROS2-Simple-Publisher-Subscriber.md
+++ b/workshop/source/_source/basics/ROS2-Simple-Publisher-Subscriber.md
@@ -1,6 +1,6 @@
 
 # Understanding ROS 2 nodes with a simple Publisher - Subscriber pair
-**Based on the [ROS 2 Tutorials](https://index.ros.org/doc/ros2/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber/)**
+**Based on the [ROS 2 Tutorials](https://docs.ros.org/en/foxy/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber.html)**
 
 ## Introduction
 

--- a/workshop/source/_source/basics/ROS2-Simple-Publisher-Subscriber.md
+++ b/workshop/source/_source/basics/ROS2-Simple-Publisher-Subscriber.md
@@ -1,10 +1,10 @@
 
-# Understanding ROS2 nodes with a simple Publisher - Subscriber pair
-**Based on the [ROS2 Tutorials](https://index.ros.org/doc/ros2/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber/)**
+# Understanding ROS 2 nodes with a simple Publisher - Subscriber pair
+**Based on the [ROS 2 Tutorials](https://index.ros.org/doc/ros2/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber/)**
 
 ## Introduction
 
-As we understood from the lectures, nodes are the fundamental units in ROS2 which are usually written to perform a specific task. They can be created in a few different ways such as- 
+As we understood from the lectures, nodes are the fundamental units in ROS 2 which are usually written to perform a specific task. They can be created in a few different ways such as- 
 1. As simple in-line code in a script,
 2. As local functions, and
 3. As class objects   
@@ -19,13 +19,13 @@ The first step is to create a python package to house all our nodes. You can do 
 $ ros2 pkg create --build-type ament_python <package_name>
 ```
 
-(Make sure first that ROS2 is sourced in every new terminal)
+(Make sure first that ROS 2 is sourced in every new terminal)
 
 Make sure you run this command in the *src* directory of your workspace. You can use any package name you want, but for reference in this document, we call it `wshop_nodes`.
 
 ## 1. Publisher Node
 
-The publisher and subscriber nodes used here are in fact the [example code](https://github.com/ros2/examples/blob/master/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py) that ROS2 provides.
+The publisher and subscriber nodes used here are in fact the [example code](https://github.com/ros2/examples/blob/master/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py) that ROS 2 provides.
 
 We first present the code completely, and then discuss the interesting parts:
 
@@ -83,7 +83,7 @@ from rclpy.node import Node
 from std_msgs.msg import String
 ```
 
-`rclpy` is the *ROS2 Client Library* that provides the API for invoking ROS2 through Python.   
+`rclpy` is the *ROS 2 Client Library* that provides the API for invoking ROS 2 through Python.   
 `Node` is the main class which will be inherited here to instantiate our own node.   
 `std_msgs.msg` is the library for standard messages that includes the `String` message type which we use in this node. This has to be declared as a dependency in `package.xml`, which we do next.   
 
@@ -174,12 +174,12 @@ entry_points={
 ```
 In this case, `talker` is the name we assign to the executable, `wshop_nodes` is the package, `minimal_publisher` is the name of the python file and `main` is the entry point to this executable (i.e. main function). Replace with the names you chose accordingly.
 
-You can use the same prototype to declare executables in all ROS2 python packages.
+You can use the same prototype to declare executables in all ROS 2 python packages.
 
 
 ### 1.4 Setup.cfg
 
-The final configuration file is `setup.cfg`, which, fortunately for us, is already configured properly and needs no more changes! These settings indicate to ROS2 where the executable shall be put for discovery after building the package.
+The final configuration file is `setup.cfg`, which, fortunately for us, is already configured properly and needs no more changes! These settings indicate to ROS 2 where the executable shall be put for discovery after building the package.
 
 ## 2 Subscriber Node
 
@@ -268,7 +268,7 @@ entry_points={
 Before building, it is always good to check if all dependencies have been installed. We execute the following from the **base workspace folder** (i.e. just above the src folder of your **workspace**):
 
 `rosdep install --from-paths src --ignore-src -r --rosdistro <distro> -y`   
-Substitute <distro> with the current version of ROS2 you are running on. Ex: `foxy`
+Substitute <distro> with the current version of ROS 2 you are running on. Ex: `foxy`
 
 From the same location, build the workspace:
 
@@ -282,7 +282,7 @@ Finally, we are ready to run an executable. Recalling from section **1.3**, the 
 
 `ros2 run wshop_nodes talker`
 
-Open another terminal and similarly source ros2 and this workspace to run the subscriber executable:
+Open another terminal and similarly source ROS 2 and this workspace to run the subscriber executable:
 
 `ros2 run wshop_nodes listener`
 

--- a/workshop/source/_source/basics/ROS2-Turtlesim.md
+++ b/workshop/source/_source/basics/ROS2-Turtlesim.md
@@ -2,23 +2,23 @@
 
 ## 1. Introduction
 
-Turtlesim is the Flagship example application for ROS and ROS2. It demonstrates in simple but effective ways the basic concepts.
+Turtlesim is the Flagship example application for ROS and ROS 2. It demonstrates in simple but effective ways the basic concepts.
 
 This workshop encourages you to refer to the cheat sheet for the syntax and type the commands on your own in order to learn by trial and error. Make use of the `--help` option for commands as well. However, solutions are also provided in the end. Feel free to approach this any way as you wish.      
 
 <!--## Requirements
 `sudo apt install ros-foxy-turtlesim`   
-Make sure ROS2 is sourced in every terminal you open.   -->
+Make sure ROS 2 is sourced in every terminal you open.   -->
 
 ## 2. Starting the Turtle simulator
 
 You can start the main application by simply executing two of its nodes. Refer to the cheat sheet for the syntax to execute a node. 
 
-The package name you need in this case is `turtlesim` and the nodes you need to start are `turtlesim_node` and `turtle_teleop_key`. Make sure to source ROS2 and run these nodes in two separate terminals.      
+The package name you need in this case is `turtlesim` and the nodes you need to start are `turtlesim_node` and `turtle_teleop_key`. Make sure to source ROS 2 and run these nodes in two separate terminals.      
 
 > Start the 2 nodes of the application
 
-Once you successfully start these nodes, you should see a window popup with a blue background and a random turtle in the middle (this is an RQT pane, if you are interested in knowing!). This little guy is going to help us understand ROS2. We should treat it as if it is an AGV (Automated Guided Vehicle), and we observe this scene from a top down perspective.
+Once you successfully start these nodes, you should see a window popup with a blue background and a random turtle in the middle (this is an RQT pane, if you are interested in knowing!). This little guy is going to help us understand ROS 2. We should treat it as if it is an AGV (Automated Guided Vehicle), and we observe this scene from a top down perspective.
 
 Before moving the turtle, you might find it useful to right click on the title bar of the simulator screen and select *Always on top* (undo this when you no longer need it). 
 
@@ -122,7 +122,7 @@ In a separate terminal start recording a ros2bag file with the selected topic `/
 Replay this ros2bag file, and you will notice the turtle moving in the same way as you recorded.
 
 ## 6. Advanced - Remapping and other options
-Every ROS2 command and sub-command has a list of options that you can use to modify its behavior. The list of options can be seen with `-h` and included as desired. You can experiment with these as well and see how the commands you have already executed so far change.   
+Every ROS 2 command and sub-command has a list of options that you can use to modify its behavior. The list of options can be seen with `-h` and included as desired. You can experiment with these as well and see how the commands you have already executed so far change.   
 
 For example, when you publish a velocity command from CLI, it publishes this message continuously and the turtle keeps moving until you kill the publisher. You could instead give a `-r 0.5` option to make it publish at 0.5 Hz. meaning there is a slight pause before every movement.    
 

--- a/workshop/source/_source/navigation/ROS2-Cartographer.md
+++ b/workshop/source/_source/navigation/ROS2-Cartographer.md
@@ -1,4 +1,4 @@
-# ROS2-Cartographer
+# ROS 2 Cartographer
 
 ## 1. Introduction
 - The goal of this tutorial is to
@@ -45,7 +45,7 @@ source: [cartographer](https://google-cartographer.readthedocs.io/en/latest/)
 #### 3.2.1. Check if there are cartographer packages
 
     ```bash
-    # source ROS2
+    # source ROS 2
     $ source /opt/ros/foxy/setup.bash
 
     $ ros2 pkg list |grep cartographer
@@ -89,7 +89,7 @@ Make sure you have "src" folder, then run this command to get source code for tu
 ```bash
 $ vcs import src<turtlebot3.repos
 ```
-Source your ROS2 installation workspace and install dependencies
+Source your ROS 2 installation workspace and install dependencies
 
 ```bash
 $ source /opt/ros/foxy/setup.bash

--- a/workshop/source/_source/navigation/ROS2-Navigation.md
+++ b/workshop/source/_source/navigation/ROS2-Navigation.md
@@ -1,8 +1,8 @@
-# ROS2 Navigation
+# ROS 2 Navigation
 
 ## 1. Introduction
 - The goal of this tutorial is  
-    - to use the ROS2 navigation capabilities to move the robot autonomously.
+    - to use the ROS 2 navigation capabilities to move the robot autonomously.
 - The packages you will use:
     - workshop_ros2_navigation
 

--- a/workshop/source/_source/navigation/ROS2-TF2.md
+++ b/workshop/source/_source/navigation/ROS2-TF2.md
@@ -5,7 +5,7 @@ This tutorial will help you understand the flexibility of transforms with the TF
 
 For this tutorial, we will use the Turtlesim again. This time, we will insert a second turtle into the simulation. As you drive the first turtle around with keyboard teleop, the second turte will follow it closely. In order to do this, the second turtle needs to know where the first one is, w.r.t. its own coordinate frames. This can be easily achieved using the TF2 library.
 
-The example code is based on [tf2_example](https://github.com/ros2/geometry2/tree/eloquent/examples_tf2_py) and is tested with ROS2 Foxy.   
+The example code is based on [tf2_example](https://github.com/ros2/geometry2/tree/eloquent/examples_tf2_py) and is tested with ROS 2 Foxy.   
 
 
 
@@ -88,7 +88,7 @@ Next, add this script to the
 
 ### 1.1 Explanation
 
-This follows the same basic structure for a ROS2 node. The TF2 specific lines will be explained.
+This follows the same basic structure for a ROS 2 node. The TF2 specific lines will be explained.
 
 ```python
 from geometry_msgs.msg import TransformStamped
@@ -96,7 +96,7 @@ from scipy.spatial.transform import Rotation as R
 from tf2_ros.transform_broadcaster import TransformBroadcaster
 ```
 
-Imports the modules required for TF2. Scipy is used to convert from Euler angles to quaternion since the `tf_conversions` package has not been ported over to ROS2 yet.
+Imports the modules required for TF2. Scipy is used to convert from Euler angles to quaternion since the `tf_conversions` package has not been ported over to ROS 2 yet.
 
 ```python
 self.tfb_ = TransformBroadcaster(self)

--- a/workshop/source/_source/navigation/ROS2-Turtlebot.md
+++ b/workshop/source/_source/navigation/ROS2-Turtlebot.md
@@ -1,4 +1,4 @@
-# TurtleBot in ROS2
+# TurtleBot in ROS 2
 
 ## 1. Introduction
 
@@ -214,7 +214,7 @@ You can use Joystick axis and joystick angular axis to control turtlbot.
 ## 5. Physical TurtleBot3
 In this chapter you will learn how to use physical TurtleBot
 
-### 5.1. Setting up to a turtlebot ROS2 Network 
+### 5.1. Setting up to a turtlebot ROS 2 Network 
 Info: The computer of the real robot will be accessed from your local computer remotely. For every further command, a tag will inform which computer has to be used. It can be either `[TurtleBot]` or `[Remote PC]`.
 
 As the robot you are using does not have any input devices or monitor, we have to start it in another way. Luckily we can work remotely from a local workstation using SSH. SSH provides a secure communication channel over an unsecured network in a client-server architecture. It connects an SSH client application with an SSH server.
@@ -273,7 +273,7 @@ $ ros2 launch turtlebot3_bringup robot.launch.py
 
 Afterwards, you can again check the nodes within a terminal of the local machine to see which applications are running within the same ROS Network.
 
-***Hint: The ROS2 DOMAIN ID of TurtleBot must be exported on every new terminal of the [Remote PC]!***
+***Hint: The ROS 2 DOMAIN ID of TurtleBot must be exported on every new terminal of the [Remote PC]!***
 
 `[Remote PC]`
 

--- a/workshop/source/conf.py
+++ b/workshop/source/conf.py
@@ -12,7 +12,7 @@ import sys
 sys.path.insert(0, os.path.abspath('.'))
 from sphinx import version_info as sphinx_version_info
 # -- Project information -----------------------------------------------------
-project = 'ROS2 workshop'
+project = 'ROS 2 workshop'
 copyright = '2021, Fraunhofer IPA'
 author = 'Ragesh Ramachandran'
 # -- General configuration ---------------------------------------------------
@@ -88,4 +88,4 @@ html_context = {
     "css_files": ['_static/override.css'],
 }
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'ROS2 workshop' """
+htmlhelp_basename = 'ROS 2 workshop' """

--- a/workshop/source/index.rst
+++ b/workshop/source/index.rst
@@ -1,33 +1,33 @@
-.. ROS2 workshop index page, created by
+.. ROS 2 workshop index page, created by
    sphinx-quickstart on Fri Feb  5 13:33:39 2021.
    Each new `Session` should contain the root [toctree](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-toctree) directive.
 
-Welcome to ROS2 workshop!
-=========================
+Welcome to ROS 2 workshop!
+==========================
 
-Session 1 - ROS2 Concepts and Fundamentals
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Session 1 - ROS 2 Concepts and Fundamentals
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. toctree::
    :maxdepth: 1
 
-   Exercise 1.0 - ROS2 filesystem <_source/basics/ROS2-Filesystem.md>
-   Exercise 1.1 - ROS2-Simple-Publisher-Subscriber <_source/basics/ROS2-Simple-Publisher-Subscriber.md>
-   Exercise 1.2 - ROS2-Turtlesim <_source/basics/ROS2-Turtlesim.md>
+   Exercise 1.0 - ROS-2-Filesystem <_source/basics/ROS2-Filesystem.md>
+   Exercise 1.1 - ROS-2-Simple-Publisher-Subscriber <_source/basics/ROS2-Simple-Publisher-Subscriber.md>
+   Exercise 1.2 - ROS-2-Turtlesim <_source/basics/ROS2-Turtlesim.md>
 
-Session 2 - ROS2 Navigation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. toctree::
-   :maxdepth: 1
-
-   Exercise 2.1 - ROS2-TF2 <_source/navigation/ROS2-TF2.md>
-   Exercise 2.2 - ROS2-Turtlebot <_source/navigation/ROS2-Turtlebot.md>
-   Exercise 2.3 - ROS2-Cartographer <_source/navigation/ROS2-Cartographer.md>
-   Exercise 2.4 - ROS2-Navigation <_source/navigation/ROS2-Navigation.md>
-
-Session 3 - ROS2 Manipulation
+Session 2 - ROS 2 Navigation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. toctree::
    :maxdepth: 1
 
-   Exercise 3 - ROS2-Moveit2 <_source/manipulation/readme.md>
+   Exercise 2.1 - ROS-2-TF2 <_source/navigation/ROS2-TF2.md>
+   Exercise 2.2 - ROS-2-Turtlebot <_source/navigation/ROS2-Turtlebot.md>
+   Exercise 2.3 - ROS-2-Cartographer <_source/navigation/ROS2-Cartographer.md>
+   Exercise 2.4 - ROS-2-Navigation <_source/navigation/ROS2-Navigation.md>
+
+Session 3 - ROS 2 Manipulation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. toctree::
+   :maxdepth: 1
+
+   Exercise 3 - ROS-2-Moveit2 <_source/manipulation/readme.md>
    


### PR DESCRIPTION
This changes "ROS2" to "ROS 2" in text and updates docs links from index.ros.org to docs.ros.org

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>