### PR TITLE
Remove unfinished sentence

### DIFF
--- a/workshop/source/_source/navigation/ROS2-TF2.md
+++ b/workshop/source/_source/navigation/ROS2-TF2.md
@@ -84,7 +84,6 @@ if __name__ == "__main__":
     main()
 
 ```
-Next, add this script to the 
 
 ### 1.1 Explanation
 


### PR DESCRIPTION
Probably was going to say 

> Next, add this script to the **executables**

I guess, but this happens later in the tutorial