### PR TITLE
Restructure workshop navigation and add Getting Started guides

### DIFF
--- a/workshop/source/_source/basics/ROS2-Filesystem.md
+++ b/workshop/source/_source/basics/ROS2-Filesystem.md
@@ -122,9 +122,9 @@ Build-from-source packages can be divided into packages provided by ROS 2 and yo
 
     ***Note: Don’t forget to source the ROS installation before build and make sure you are in the root of workspace(~/dev_ws).***
     ```bash
-    $ source /opt/ros/jazzy/setup.bash
+    source /opt/ros/jazzy/setup.bash
 
-    $ colcon build --symlink-install
+    colcon build --symlink-install
     ```
 
 * Source the overlay
@@ -135,8 +135,8 @@ Build-from-source packages can be divided into packages provided by ROS 2 and yo
     - you can start a new terminal window by   `ctl + alt +t`
 
     ```bash
-    $ cd dev_ws
-    $ source install/setup.bash
+    cd dev_ws
+    source install/setup.bash
     ```
 
 ## 5. ROS nodes

--- a/workshop/source/_source/basics/index.rst
+++ b/workshop/source/_source/basics/index.rst
@@ -1,0 +1,10 @@
+ROS 2 basics
+============
+
+.. toctree::
+   :maxdepth: 1
+
+   File system <ROS2-Filesystem>
+   Publisher and subscriber <ROS2-Simple-Publisher-Subscriber>
+   Turtlesim <ROS2-Turtlesim>
+   TF2 <../navigation/ROS2-TF2>

--- a/workshop/source/_source/control/index.rst
+++ b/workshop/source/_source/control/index.rst
@@ -1,0 +1,12 @@
+ROS 2 control
+=============
+
+.. toctree::
+   :maxdepth: 1
+
+   RRBot <01_Example>
+   DiffBot <02_Example>
+   Robots with multiple interfaces <03_Example>
+   Industrial robot with an externally connected sensor <04_Example>
+   WBot mobile manipulator <05_Example>
+   Tricycle robot setup <06_Example>

--- a/workshop/source/_source/getting_started/docker.md
+++ b/workshop/source/_source/getting_started/docker.md
@@ -1,0 +1,138 @@
+# Docker basics
+
+Docker is optional for the ROS 2 exercises, but it is useful when a tool should
+run without installing all of its dependencies on the host computer. This
+repository also uses Docker Compose to export the workshop slides without
+installing Node.js locally.
+
+Follow the official [Docker Engine installation instructions for
+Ubuntu](https://docs.docker.com/engine/install/ubuntu/). Complete Docker's
+post-installation steps if workshop commands should run without `sudo`.
+Membership in the `docker` group grants elevated privileges, so only enable it
+on a computer where that access is appropriate.
+
+## Core concepts
+
+| Term | Meaning |
+| --- | --- |
+| Image | A read-only template containing an application and its dependencies |
+| Container | A running or stopped instance of an image |
+| Dockerfile | Instructions for building an image |
+| Compose file | Configuration for one or more related containers |
+| Volume | Data or a directory mounted into a container |
+
+## Verify Docker
+
+```bash
+docker --version
+docker compose version
+docker run --rm hello-world
+```
+
+The final command downloads a small test image, runs it, and removes the
+container after it exits.
+
+## Images
+
+Download an image:
+
+```bash
+docker pull ubuntu:24.04
+```
+
+List local images:
+
+```bash
+docker images
+```
+
+Build an image from a Dockerfile in the current directory:
+
+```bash
+docker build -t my_image .
+```
+
+## Containers
+
+Start an interactive Ubuntu container:
+
+```bash
+docker run --rm -it ubuntu:24.04
+```
+
+The `--rm` option removes the container when it exits.
+
+Start and name a container:
+
+```bash
+docker run -it --name my_container ubuntu:24.04
+```
+
+List running containers or all containers:
+
+```bash
+docker ps
+docker ps -a
+```
+
+Start an existing stopped container and open a shell:
+
+```bash
+docker start my_container
+docker exec -it my_container bash
+```
+
+Stop and remove it:
+
+```bash
+docker stop my_container
+docker rm my_container
+```
+
+## Docker Compose
+
+Compose reads a `compose.yaml` file and manages its services together.
+
+```bash
+docker compose up
+docker compose ps
+docker compose logs
+docker compose down
+```
+
+Run a one-off service and remove its container afterward:
+
+```bash
+docker compose run --rm SERVICE_NAME
+```
+
+Rebuild service images before starting:
+
+```bash
+docker compose up --build
+```
+
+## Build the workshop slides
+
+The slides provide their own Compose configuration. From the repository root:
+
+```bash
+cd slides
+HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose run --rm slides
+```
+
+The generated PDFs are written to the repository's `export` directory by
+default. Node.js, Chromium, and the slide exporter remain inside the container.
+
+## Exercise
+
+1. Run an interactive `ubuntu:24.04` container.
+2. Inside the container, display the Ubuntu release information.
+3. Exit the container and confirm that it was removed.
+
+```bash
+docker run --rm -it ubuntu:24.04
+cat /etc/os-release
+exit
+docker ps -a
+```

--- a/workshop/source/_source/getting_started/git_and_vcstool.md
+++ b/workshop/source/_source/getting_started/git_and_vcstool.md
@@ -1,0 +1,180 @@
+# Git and vcstool
+
+Git records changes to files over time. It enables you to inspect history,
+develop work on branches, and collaborate through a remote service such as
+GitHub.
+
+## Git concepts
+
+| Term | Meaning |
+| --- | --- |
+| Repository | A project and its Git history |
+| Commit | A saved snapshot with a message |
+| Branch | A named line of development |
+| Remote | A repository stored elsewhere, such as on GitHub |
+| Working tree | The files currently checked out |
+| Staging area | Changes selected for the next commit |
+
+## Configure your identity
+
+Git stores an author name and email in every commit:
+
+```bash
+git config --global user.name "Your Name"
+git config --global user.email "you@example.com"
+```
+
+Inspect the configuration:
+
+```bash
+git config --global --list
+```
+
+## Clone a repository
+
+```bash
+git clone https://github.com/ros-industrial/ros2_i_training.git
+cd ros2_i_training
+```
+
+## Typical workflow
+
+Check the current state:
+
+```bash
+git status
+```
+
+Create and switch to a branch:
+
+```bash
+git switch -c workshop-notes
+```
+
+Inspect unstaged changes:
+
+```bash
+git diff
+```
+
+Select changes and create a commit:
+
+```bash
+git add notes.txt
+git commit -m "Add workshop notes"
+```
+
+Inspect the history:
+
+```bash
+git log --oneline
+```
+
+Download changes from the remote and upload local commits:
+
+```bash
+git pull
+git push
+```
+
+Pushing requires permission to the remote repository. When contributing through
+a fork, push the branch to your fork and open a pull request against the
+upstream repository.
+
+## HTTPS and SSH remotes
+
+An HTTPS remote looks like:
+
+```text
+https://github.com/ros-industrial/ros2_i_training.git
+```
+
+An SSH remote looks like:
+
+```text
+git@github.com:ros-industrial/ros2_i_training.git
+```
+
+HTTPS is simple for read-only access. SSH is convenient for regular
+authenticated pushes after an SSH key has been configured.
+
+Inspect the configured remotes:
+
+```bash
+git remote -v
+```
+
+Change the URL of the remote named `origin`:
+
+```bash
+git remote set-url origin git@github.com:ros-industrial/ros2_i_training.git
+```
+
+## Good habits
+
+- Run `git status` frequently.
+- Work on a branch rather than directly on `main`.
+- Keep commits focused on one logical change.
+- Write commit messages that explain the change.
+- Review `git diff` before committing.
+- Pull recent upstream changes before beginning new work.
+
+## Git exercise
+
+This exercise uses a new local repository and does not require GitHub access:
+
+```bash
+mkdir -p ~/ros2_workshop/git_exercise
+cd ~/ros2_workshop/git_exercise
+git init
+git switch -c workshop-notes
+touch notes.txt
+git status
+git add notes.txt
+git commit -m "Add workshop notes"
+git log --oneline
+```
+
+If Git refuses to create the commit, configure your author name and email as
+shown earlier on this page.
+
+## Managing several repositories with vcstool
+
+A ROS 2 workspace can depend on several Git repositories. `vcstool` reads a
+`.repos` file and checks out each repository at the requested branch, tag, or
+commit.
+
+Install it if necessary:
+
+```bash
+sudo apt update
+sudo apt install python3-vcstool
+```
+
+Example `dependencies.repos`:
+
+```yaml
+repositories:
+  example_interfaces:
+    type: git
+    url: https://github.com/ros2/example_interfaces.git
+    version: jazzy
+```
+
+Import the repositories into a workspace:
+
+```bash
+mkdir -p dev_ws/src
+cd dev_ws
+vcs import src < dependencies.repos
+```
+
+Inspect their versions and local changes:
+
+```bash
+vcs status src
+```
+
+The space before `<` is optional to Bash but is kept here for readability.
+The operator redirects the contents of `dependencies.repos` into
+`vcs import`.

--- a/workshop/source/_source/getting_started/index.rst
+++ b/workshop/source/_source/getting_started/index.rst
@@ -1,4 +1,15 @@
 Getting started
 ===============
 
-Getting-started material will be added here.
+The following pages prepare your computer and introduce the tools used
+throughout the workshop.
+
+.. toctree::
+   :maxdepth: 1
+
+   Prerequisites <prerequisites>
+   Linux and terminal basics <linux_and_terminal>
+   Terminator <terminator>
+   Networking basics <networking>
+   Git and vcstool <git_and_vcstool>
+   Docker basics (optional) <docker>

--- a/workshop/source/_source/getting_started/index.rst
+++ b/workshop/source/_source/getting_started/index.rst
@@ -1,0 +1,4 @@
+Getting started
+===============
+
+Getting-started material will be added here.

--- a/workshop/source/_source/getting_started/linux_and_terminal.md
+++ b/workshop/source/_source/getting_started/linux_and_terminal.md
@@ -1,0 +1,144 @@
+# Linux and terminal basics
+
+The terminal is a text-based way to interact with the computer. ROS 2
+development uses terminals to navigate directories, build workspaces, source
+environments, and start nodes.
+
+## Essential commands
+
+### Show the current directory
+
+```bash
+pwd
+```
+
+### List files and directories
+
+```bash
+ls
+ls -l
+```
+
+`ls -l` also displays permissions, ownership, size, and modification time.
+
+### Change directory
+
+```bash
+cd ~/ros2_workshop
+cd ..
+cd -
+```
+
+- `..` is the parent directory.
+- `~` is your home directory.
+- `cd -` returns to the previous directory.
+
+### Create directories
+
+```bash
+mkdir my_directory
+mkdir -p dev_ws/src
+```
+
+The `-p` option creates missing parent directories.
+
+### Copy and move files
+
+```bash
+cp source.txt destination.txt
+mv old_name.txt new_name.txt
+```
+
+`mv` can rename a file or move it into another directory.
+
+### Create and inspect files
+
+```bash
+touch notes.txt
+less notes.txt
+```
+
+Press `q` to leave `less`.
+
+## Permissions and scripts
+
+The permission string shown by `ls -l` may look like:
+
+```text
+-rw-rw-r-- 1 user user 29 Apr 13 10:00 hello_world.sh
+```
+
+The three permission groups apply to the owner, group, and others:
+
+- `r`: read
+- `w`: write
+- `x`: execute
+- `-`: permission not granted
+
+Make a script executable and run it:
+
+```bash
+chmod +x hello_world.sh
+./hello_world.sh
+```
+
+A script can also be passed directly to Bash:
+
+```bash
+bash hello_world.sh
+```
+
+## Using sudo safely
+
+`sudo` runs a command with administrator privileges. It is normally needed
+for system-wide actions such as installing packages:
+
+```bash
+sudo apt update
+```
+
+Do not use `sudo` for ordinary work in your home directory. A mistaken
+administrator command can modify or damage the system.
+
+## Useful terminal features
+
+- Press `Tab` to complete command and file names.
+- Press the up and down arrows to browse command history.
+- Press `Ctrl+C` to interrupt a running foreground command.
+- Use `clear` or press `Ctrl+L` to clear the terminal display.
+- Run `pwd` when you are uncertain about the current directory.
+
+## Exercise
+
+1. Create `~/ros2_workshop/linux_exercise`.
+2. Inside it, create the directories `source` and `workspace/src`.
+3. In `source`, create `hello_world.sh` with this content:
+
+   ```bash
+   #!/usr/bin/env bash
+
+   echo "Hello world"
+   ```
+
+4. Copy the script into `workspace/src`.
+5. Make the copied script executable.
+6. Run it from `workspace/src`.
+
+### Solution
+
+```bash
+mkdir -p ~/ros2_workshop/linux_exercise/source
+mkdir -p ~/ros2_workshop/linux_exercise/workspace/src
+cd ~/ros2_workshop/linux_exercise/source
+nano hello_world.sh
+cp hello_world.sh ../workspace/src/
+cd ../workspace/src
+chmod +x hello_world.sh
+./hello_world.sh
+```
+
+Expected output:
+
+```text
+Hello world
+```

--- a/workshop/source/_source/getting_started/networking.md
+++ b/workshop/source/_source/getting_started/networking.md
@@ -1,0 +1,111 @@
+# Networking basics
+
+ROS 2 systems often communicate across a network, for example between a laptop
+and a robot computer. This page introduces the Linux networking commands used
+in the workshop.
+
+## IP addresses
+
+Each network interface normally has an IP address. An address such as
+`192.168.3.42` identifies a computer on a local network.
+
+Show the interfaces and their addresses:
+
+```bash
+ip addr
+```
+
+Show only the addresses assigned to the computer:
+
+```bash
+hostname -I
+```
+
+Interface names vary between computers. Typical names include:
+
+- `lo`: the local loopback interface
+- `enp...` or `eth...`: an Ethernet interface
+- `wlp...` or `wlan...`: a Wi-Fi interface
+
+The older `ifconfig` command may not be installed by default. Prefer
+`ip addr` on current Ubuntu systems.
+
+## Check connectivity with ping
+
+`ping` tests whether another machine is reachable:
+
+```bash
+ping -c 4 192.168.3.42
+```
+
+The `-c 4` option stops after four requests. Without it, press `Ctrl+C` to
+stop the command.
+
+A successful response looks similar to:
+
+```text
+64 bytes from 192.168.3.42: icmp_seq=1 ttl=64 time=1.23 ms
+```
+
+A failed ping can mean that the target is offline, connected to a different
+network, using a different address, or blocking ping with a firewall.
+
+## Connect with SSH
+
+SSH opens a secure terminal on another computer:
+
+```bash
+ssh student@192.168.3.42
+```
+
+The first connection may ask you to confirm the remote host fingerprint. Verify
+the address before accepting it. Leave the remote session with:
+
+```bash
+exit
+```
+
+## Copy files with scp
+
+Copy a local file to a remote computer:
+
+```bash
+scp my_file.txt student@192.168.3.42:/home/student/
+```
+
+Copy a remote file into the current local directory:
+
+```bash
+scp student@192.168.3.42:/home/student/my_file.txt .
+```
+
+Copy a directory recursively:
+
+```bash
+scp -r my_directory student@192.168.3.42:/home/student/
+```
+
+## ROS 2 networking checklist
+
+For two ROS 2 computers to discover each other:
+
+1. Connect them to the same network.
+2. Confirm that they can reach each other.
+3. Use compatible ROS 2 distributions and middleware configurations.
+4. Set the same `ROS_DOMAIN_ID` on machines that should communicate.
+5. Check firewall and multicast settings if discovery still fails.
+
+Display the configured domain:
+
+```bash
+printenv ROS_DOMAIN_ID
+```
+
+## Exercise
+
+1. Connect to the network specified by the instructor.
+2. Find your computer's IP address with `ip addr` or `hostname -I`.
+3. Exchange IP addresses with another participant.
+4. Test both directions with `ping`.
+5. If SSH is enabled, connect to the other computer using the account provided
+   by the instructor.

--- a/workshop/source/_source/getting_started/prerequisites.md
+++ b/workshop/source/_source/getting_started/prerequisites.md
@@ -1,0 +1,104 @@
+# Prerequisites
+
+Prepare the computer before starting the exercises. The workshop assumes an
+Ubuntu installation with a matching ROS 2 distribution.
+
+## Supported environments
+
+| Ubuntu | ROS 2 |
+| --- | --- |
+| Ubuntu 24.04 | Jazzy |
+| Ubuntu 22.04 | Humble |
+
+Use the ROS 2 distribution that matches your Ubuntu version. Do not source two
+ROS 2 distributions in the same terminal.
+
+Follow the official ROS 2 installation instructions:
+
+- [Install ROS 2 Jazzy on Ubuntu 24.04](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html)
+- [Install ROS 2 Humble on Ubuntu 22.04](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debs.html)
+
+Install the command-line tools used during the workshop:
+
+```bash
+sudo apt update
+sudo apt install git terminator python3-vcstool python3-colcon-common-extensions
+```
+
+Docker and Visual Studio Code are useful but optional:
+
+- [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/)
+- [Install Visual Studio Code on Linux](https://code.visualstudio.com/docs/setup/linux)
+
+## Check the installation
+
+Check the Ubuntu version:
+
+```bash
+lsb_release -ds
+```
+
+Source the ROS 2 installation. This example uses Jazzy:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+```
+
+For Ubuntu 22.04 with ROS 2 Humble, use:
+
+```bash
+source /opt/ros/humble/setup.bash
+```
+
+Verify the tools:
+
+```bash
+printenv ROS_DISTRO
+ros2 --help
+colcon --help
+vcs help
+git --version
+```
+
+The first command should print the ROS 2 distribution selected above.
+
+## Configure Bash
+
+ROS 2 must be sourced in every new terminal. To source it automatically, add
+the appropriate setup command to `~/.bashrc`. Add only one ROS 2 distribution.
+
+For Jazzy:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash
+```
+
+For Humble, replace `jazzy` with `humble`.
+
+Apply changes made to `~/.bashrc` in the current terminal:
+
+```bash
+source ~/.bashrc
+```
+
+## Set the ROS domain
+
+`ROS_DOMAIN_ID` separates independent ROS 2 systems on the same network.
+During a workshop, use the domain ID assigned by the instructor so that
+participants do not interfere with one another.
+
+For example:
+
+```bash
+export ROS_DOMAIN_ID=10
+```
+
+Add the export to `~/.bashrc` if it should apply to every new terminal. All
+machines that need to communicate with each other must use the same domain ID.
+
+Check the current value:
+
+```bash
+printenv ROS_DOMAIN_ID
+```

--- a/workshop/source/_source/getting_started/terminator.md
+++ b/workshop/source/_source/getting_started/terminator.md
@@ -1,0 +1,51 @@
+# Terminator
+
+Terminator is a terminal emulator that can split one window into several
+terminals. This is convenient for ROS 2 exercises because several nodes often
+need to run simultaneously.
+
+## Install Terminator
+
+```bash
+sudo apt update
+sudo apt install terminator
+```
+
+Start it from an existing terminal:
+
+```bash
+terminator
+```
+
+It can also be opened from the Ubuntu application menu.
+
+## Useful shortcuts
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl+Shift+O` | Split horizontally |
+| `Ctrl+Shift+E` | Split vertically |
+| `Ctrl+Shift+T` | Open a new tab |
+| `Ctrl+Tab` | Move to the next terminal |
+| `Ctrl+Shift+N` | Move to the next terminal |
+| `Ctrl+Shift+W` | Close the current terminal |
+
+## Suggested workshop layout
+
+A useful layout is:
+
+- one terminal for building the workspace
+- one terminal for running a ROS 2 node
+- one terminal for inspecting topics, services, or actions
+
+Each new terminal needs the ROS 2 environment and, when applicable, the
+workspace environment:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source ~/dev_ws/install/setup.bash
+```
+
+Use `/opt/ros/humble/setup.bash` instead when working with ROS 2 Humble.
+
+Run `pwd` in each terminal if you are unsure which directory it is using.

--- a/workshop/source/_source/manipulation/index.rst
+++ b/workshop/source/_source/manipulation/index.rst
@@ -1,0 +1,9 @@
+ROS 2 Manipulation
+==================
+
+.. toctree::
+   :maxdepth: 1
+
+   MoveIt Setup Assistant <setup_assistance>
+   URDF introduction <../urdf/introduction>
+   Cartesian robot <../urdf/cartesian_tutorial>

--- a/workshop/source/_source/navigation/ROS2-Cartographer.md
+++ b/workshop/source/_source/navigation/ROS2-Cartographer.md
@@ -46,9 +46,9 @@ source: [cartographer](https://google-cartographer.readthedocs.io/en/latest/)
 
     ```bash
     # source ROS 2
-    $ source /opt/ros/foxy/setup.bash
+    source /opt/ros/foxy/setup.bash
 
-    $ ros2 pkg list |grep cartographer
+    ros2 pkg list |grep cartographer
 
     # You will get
     # cartographer_ros
@@ -60,13 +60,13 @@ If you don't have "cartographer_ros" and "cartographer_ros_msgs", you can instal
 **Before installing package, you need to make sure which ROS distribution you are using.**
 
 ```bash
-$ sudo apt install ros-$ROS_DISTRO-cartographer
+sudo apt install ros-$ROS_DISTRO-cartographer
 ```
 
 #### 3.2.2. Check if there are turtlebot3* packages
 
 ```bash
-$ ros2 pkg list | grep turtlebot3
+ros2 pkg list | grep turtlebot3
 ```
 If you don't have turtlebot3 packages, you can install debian packages or from source code.
 
@@ -81,30 +81,30 @@ B. Install from source code
 First entering your workspace
 
 ```bash
-$ wget https://raw.githubusercontent.com/ROBOTIS-GIT/turtlebot3/foxy-devel/turtlebot3.repos
+wget https://raw.githubusercontent.com/ROBOTIS-GIT/turtlebot3/foxy-devel/turtlebot3.repos
 ```
 
 Make sure you have "src" folder, then run this command to get source code for turtlebot3
 
 ```bash
-$ vcs import src<turtlebot3.repos
+vcs import src < turtlebot3.repos
 ```
 Source your ROS 2 installation workspace and install dependencies
 
 ```bash
-$ source /opt/ros/foxy/setup.bash
-$ rosdep update
-$ rosdep install --from-paths src --ignore-src --rosdistro
+source /opt/ros/foxy/setup.bash
+rosdep update
+rosdep install --from-paths src --ignore-src --rosdistro
 $ROS_DISTRO -y
 ```
 Compile codes
 
 ```bash
-$ colcon build
+colcon build
 ```
 Source your workspace
 ```bash
-$ source install/setup.bash
+source install/setup.bash
 ```
 
 
@@ -115,20 +115,20 @@ $ source install/setup.bash
 1. Set up turtlebot model
 
     ```bash
-    $ export TURTLEBOT3_MODEL=burger
+    export TURTLEBOT3_MODEL=burger
     ```
 
 2. Set up Gazebo model path
 
     ```bash
-    $ export GAZEBO_MODEL_PATH=`ros2 pkg \
+    export GAZEBO_MODEL_PATH=`ros2 pkg \
     prefix turtlebot3_gazebo`/share/turtlebot3_gazebo/models/
     ```
 
 3. Launch Gazebo with a simulation world
 
     ```bash
-    $ ros2 launch turtlebot3_gazebo turtlebot3_world.launch.py
+    ros2 launch turtlebot3_gazebo turtlebot3_world.launch.py
     ```
 
 
@@ -140,17 +140,17 @@ a. open a terminal and use `ssh` connect to Turtlebot3.
 
 b. bring up basic packages to start its applications.
 ```bash
-$ source .bashrc
+source .bashrc
 
-$ cd turtlebot3_ws
+cd turtlebot3_ws
 
 #Set up ROS_DOMAIN_ID
-$ export ROS_DOMAIN_ID="Your Number"
+export ROS_DOMAIN_ID="Your Number"
 # e.g. export ROS_DOMAIN_ID=11
 
-$ source install/setup.bash
+source install/setup.bash
 
-$ ros2 launch turtlebot3_bringup robot.launch.py
+ros2 launch turtlebot3_bringup robot.launch.py
 ```
 
 #### 3.3.3. Run teleoperation node
@@ -162,26 +162,26 @@ $ ros2 launch turtlebot3_bringup robot.launch.py
 2. Set up ROS environment
 
     ```bash
-    $ source /opt/ros/foxy/setup.bash
+    source /opt/ros/foxy/setup.bash
     ```
 3. (Set up ROS_DOMAIN_ID)
 
    If you set up ROS_DOMAIN_ID for running turtlebot simulation or physical turtlebot, then you need to set the same ROS_DOMAIN_ID here.
 
     ```bash
-    $ export ROS_DOMAIN_ID="Your Number"
+    export ROS_DOMAIN_ID="Your Number"
     # e.g. export ROS_DOMAIN_ID=11
     ```
 
 4. Set up turtlebot model
 
     ```bash
-    $ export TURTLEBOT3_MODEL=burger
+    export TURTLEBOT3_MODEL=burger
     ```
 5. Run teleoperation node
 
     ```bash
-    $ ros2 run turtlebot3_teleop teleop_keyboard
+    ros2 run turtlebot3_teleop teleop_keyboard
     ```
 
 
@@ -192,7 +192,7 @@ $ ros2 launch turtlebot3_bringup robot.launch.py
 2. Set up ROS environment
 
     ```bash
-    $ source /opt/ros/foxy/setup.bash
+    source /opt/ros/foxy/setup.bash
     ```
 
 3. (Set up ROS_DOMAIN_ID)
@@ -202,7 +202,7 @@ $ ros2 launch turtlebot3_bringup robot.launch.py
     `[Remote PC]`
 
     ```bash
-    $ export ROS_DOMAIN_ID="Your Number"
+    export ROS_DOMAIN_ID="Your Number"
     # e.g. export ROS_DOMAIN_ID=11
     ```
 
@@ -215,7 +215,7 @@ $ ros2 launch turtlebot3_bringup robot.launch.py
     `[Remote PC]`
 
     ```bash
-    $ ros2 launch turtlebot3_cartographer \
+    ros2 launch turtlebot3_cartographer \
     cartographer.launch.py \
     use_sim_time:=True
     ```
@@ -225,10 +225,10 @@ $ ros2 launch turtlebot3_bringup robot.launch.py
     `[Remote PC]`
 
     ```bash
-    $ ros2 run cartographer_ros occupancy_grid_node -resolution 0.05\
+    ros2 run cartographer_ros occupancy_grid_node -resolution 0.05\
     -publish_period_sec 1.0
 
-    $ ros2 run cartographer_ros cartographer_node\
+    ros2 run cartographer_ros cartographer_node\
     -configuration_directory]\
     install/turtlebot3_cartographer/share/turtlebot3_cartographer\
     /config -configuration_basename turtlebot3_lds_2d.lua
@@ -275,7 +275,7 @@ If you are satisfied with your map you can store it. You can save the map.
 2. run the map saver node.
 
     ```
-    $ ros2 run nav2_map_server map_saver_cli
+    ros2 run nav2_map_server map_saver_cli
     ```
 
     You also can define a name of the map by

--- a/workshop/source/_source/navigation/ROS2-Navigation.md
+++ b/workshop/source/_source/navigation/ROS2-Navigation.md
@@ -44,7 +44,7 @@ source: [navigataion](https://navigation.ros.org/_images/architectural_diagram.p
  You can check it using:
 
   ```bash
-  $ ros2 node list
+  ros2 node list
   ```
   The output should be empty, otherwise, there are still running processes.
 
@@ -67,9 +67,9 @@ nav_ws/
 
   `[Remote PC]`
   ```bash
-  $ cd your_workspace
-  $ touch map_server_params.yaml
-  $ nano map_server_params.yaml
+  cd your_workspace
+  touch map_server_params.yaml
+  nano map_server_params.yaml
   ```
 
   ```yaml
@@ -90,7 +90,7 @@ nav_ws/
   `[Remote PC]`
 
     ```bash
-    $ ros2 run nav2_map_server map_server \ --ros-args --params-file maps/map_server_params.yaml
+    ros2 run nav2_map_server map_server \ --ros-args --params-file maps/map_server_params.yaml
     ```
   **map_server** is  a lifecycle node and needs to be transitioned to the active state.
 
@@ -99,24 +99,24 @@ nav_ws/
 
   `[Remote PC]`
   ```bash
-  $ ros2 lifecycle list /map_server
+  ros2 lifecycle list /map_server
   ```
   Run this command to trigger **map_server**.
   ```bash
-  $ ros2 lifecycle set /map_server 1
+  ros2 lifecycle set /map_server 1
   ```
 
 
   **D. Start **rviz2** to view the map**
   Start a new terminal, source ros foxy workspace:
   ```bash
-  $ rviz2
+  rviz2
   ```
   In rviz2, choose "add", "by topic" and "/map"
 
   In other terminal, active **map_server**:
   ```bash
-  $ ros2 lifecycle set /map_server 3
+  ros2 lifecycle set /map_server 3
   ```
 
   Then you can see the map in rviz2 -->
@@ -170,25 +170,25 @@ nav_ws/
 
     * First you need to go into your workspace and source your workspace:
       ```bash
-      $ source install/setup.bash
+      source install/setup.bash
       ```
 
     * Set up Gazebo model path:
       ```bash
-      $ export GAZEBO_MODEL_PATH=`ros2 pkg \
+      export GAZEBO_MODEL_PATH=`ros2 pkg \
       prefix turtlebot3_gazebo`/share/turtlebot3_gazebo/models/
       ```
 
     * set up the robot model that you will use:
       ```bash
-      $ export TURTLEBOT3_MODEL=burger
+      export TURTLEBOT3_MODEL=burger
       ```
 
 3. Bring up Turtlebot in simulation
     ```bash
     # in the same terminal, run
 
-    $ ros2 launch turtlebot3_gazebo turtlebot3_world.launch.py
+    ros2 launch turtlebot3_gazebo turtlebot3_world.launch.py
     ```
 
 4. Start navigation stack
@@ -196,7 +196,7 @@ nav_ws/
     Open another terminal, source your workspace, set up the robot model that you will use, then
 
     ```bash
-    $ ros2 launch turtlebot3_navigation2 \
+    ros2 launch turtlebot3_navigation2 \
     navigation2.launch.py \
     use_sim_time:=true map:=maps/"you map name".yaml
     ```
@@ -227,17 +227,17 @@ Bring up basic packages to start TurtleBot3 applications.
 
 `[TurtleBot3]`
 ```bash
-$ source .bashrc
-$ ros2 launch turtlebot3_bringup robot.launch.py
+source .bashrc
+ros2 launch turtlebot3_bringup robot.launch.py
 ```
 
 `[Remote PC]`
 ```bash
-$ cd "your workspace"
-$ source install/setup.bash
-$ export ROS_DOMAIN_ID =
+cd "your workspace"
+source install/setup.bash
+export ROS_DOMAIN_ID =
  "same as ROS DOMAIN ID of the turtlebot you are using"
-$ ros2 launch turtlebot3_navigation2 navigation2.launch.py\
+ros2 launch turtlebot3_navigation2 navigation2.launch.py\
  map:=maps/map.yaml
 ```
 

--- a/workshop/source/_source/navigation/ROS2-Turtlebot.md
+++ b/workshop/source/_source/navigation/ROS2-Turtlebot.md
@@ -30,10 +30,10 @@ Before start, check if there are turtlrbot3* packages
 ```
 Source ROS workspace first
 
-$ source /opt/ros/foxy/setup.bash
+source /opt/ros/foxy/setup.bash
 ```
 ```
-$ ros2 pkg list | grep turtlebot3
+ros2 pkg list | grep turtlebot3
 ```
 If you don't have turtlebot3 packages, you can install debian packages or from source code.
 
@@ -50,14 +50,14 @@ B. Install from source code
     First entering your workspace
     (If you don't have workspace yet, you need to create one with an src folder in it)
 
-    $ wget https://raw.githubusercontent.com/ipa-rwu/\
+    wget https://raw.githubusercontent.com/ipa-rwu/\
     turtlebot3/foxy-devel/turtlebot3.repos
     ```
 *  Step 2: Using vcstools get packages
 
     Make sure you have "src" folder in you workspace, then run this command to get source code for turtlebot3.
     ```
-    $ vcs import src<turtlebot3.repos
+    vcs import src < turtlebot3.repos
     ```
 
     If you didn't install vcstools, you can install it as followed:
@@ -79,18 +79,18 @@ B. Install from source code
 
 * Step 3: Using rosdep get dependencies
     ```
-    $ rosdep update
-    $ rosdep install --from-paths src --ignore-src  -y
+    rosdep update
+    rosdep install --from-paths src --ignore-src  -y
     ```
 
 * Step 4: Install packages
     ```
-    $ colcon build --symlink-install
+    colcon build --symlink-install
     ```
 
 * Step 5: Source your workspace
     ```
-    $ source install/setup.bash
+    source install/setup.bash
     ```
 
 
@@ -105,14 +105,14 @@ In this chapter you will learn how to simulate TurtleBot in gazebo
 
     If you want to use different ROS Domain ID, you can perform:
     ```
-    $ export ROS_DOMAIN_ID=11
+    export ROS_DOMAIN_ID=11
     ```
 
 1. Set up ROS environment arguments
 
    If you use debian packages,
     ```
-    $ source  /opt/ros/foxy/setup.bash
+    source  /opt/ros/foxy/setup.bash
     ```
 
    If you use packages in your workspace:
@@ -120,19 +120,19 @@ In this chapter you will learn how to simulate TurtleBot in gazebo
     ```
     First entering your workspace
 
-    $ source  install/setup.bash
+    source  install/setup.bash
     ```
 
 2. Set up turtlebot model
 
     ```
-    $ export TURTLEBOT3_MODEL=burger
+    export TURTLEBOT3_MODEL=burger
     ```
 
 3. Set up Gazebo model path
 
     ```
-    $ export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:`ros2 pkg \
+    export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:`ros2 pkg \
     prefix turtlebot3_gazebo \
     `/share/turtlebot3_gazebo/models/
     ```
@@ -140,7 +140,7 @@ In this chapter you will learn how to simulate TurtleBot in gazebo
 4. Launch Gazebo with simulation world
 
     ```
-    $ ros2 launch turtlebot3_gazebo empty_world.launch.py
+    ros2 launch turtlebot3_gazebo empty_world.launch.py
     ```
     You also can start different world by replacing `empty_world.launch.py` with `turtlebot3_house.launch.py`
 
@@ -159,14 +159,14 @@ In general we will start a ros node that will publish to topic **/cmd_vel**
 1. Set up turtlebot model
 
     ```
-    $ export TURTLEBOT3_MODEL=burger
+    export TURTLEBOT3_MODEL=burger
     ```
 
 2. Run a teleoperation node
 
 
     ```
-    $ ros2 run turtlebot3_teleop teleop_keyboard
+    ros2 run turtlebot3_teleop teleop_keyboard
     ```
 
 If the program is successfully launched, the following output will appear in the terminal window and you can control the robot following the instruction.
@@ -192,13 +192,13 @@ CTRL-C to quit
 First of all, connect the given PS3 Joystick to the remote PC via the USB cable and install required packages for teleoperation using PS3 joystick.
 
 ```
-$ sudo pip install ds4drv
+sudo pip install ds4drv
 ```
 
 ```
-$ sudo ds4drv
-$ ros2 run joy joy_node
-$ ros2 run teleop_twist_joy teleop_node
+sudo ds4drv
+ros2 run joy joy_node
+ros2 run teleop_twist_joy teleop_node
 ```
 Button map
 ![PS3](../../_static/PS3-dualshock.jpg)
@@ -224,7 +224,7 @@ To establish a connection to a computer remotely, the username and the IP addres
 `[Remote PC]`
 
 ```bash
-$ ping <TB-IP>
+ping <TB-IP>
 ```
 
 You should see something like:
@@ -239,13 +239,13 @@ If this check has been successful one can connect remotely to the TurtleBot with
 `[Remote PC]`
 
 ```bash
-$ ssh <TB-userName>@<TB-IP>
+ssh <TB-userName>@<TB-IP>
 ```
 
 You will be asked to enter the password of the remote account, which is the one retrieved at the robot ( TB-password ). After the connection is established, the same terminal should show the following line:
 
 ```bash
-$ <TB-userName>@<TB-IP>
+<TB-userName>@<TB-IP>
 ```
 
 This means you are working from the home directory of the TurtleBot. So you can start applications running on the processor of the robot. All commands that will have to be entered during this tutorial in this terminal, will be labelled with a [**TurtleBot**] tag.
@@ -260,7 +260,7 @@ In this case, you will find environment variables are defined in the file $HOME/
 `[TurtleBot3]`
 
 ```bash
-$ source .bashrc
+source .bashrc
 ```
 
 Bring up the robot with the following launch-file:
@@ -268,7 +268,7 @@ Bring up the robot with the following launch-file:
 `[TurtleBot3]`
 
 ```bash
-$ ros2 launch turtlebot3_bringup robot.launch.py
+ros2 launch turtlebot3_bringup robot.launch.py
 ```
 
 Afterwards, you can again check the nodes within a terminal of the local machine to see which applications are running within the same ROS Network.
@@ -278,13 +278,13 @@ Afterwards, you can again check the nodes within a terminal of the local machine
 `[Remote PC]`
 
 ```bash
-$ export ROS_DOMAIN_ID = <ROS_DOMAIN_ID of TurtleBot>
+export ROS_DOMAIN_ID = <ROS_DOMAIN_ID of TurtleBot>
 ```
 
 `[Remote PC]`
 
 ```bash
-$ ros2 node list
+ros2 node list
 ```
 
 You can check all existing topics of the system:
@@ -292,19 +292,19 @@ You can check all existing topics of the system:
 `[Remote PC]`
 
 ```bash
-$ ros2 topic list
+ros2 topic list
 ```
 
 You can as well check all existing service of the system:
 
 ```bash
-$ ros2 service list
+ros2 service list
 ```
 
 You can as well check tf:
 
 ```bash
-$ ros2 run tf2_ros tf2_monitor
+ros2 run tf2_ros tf2_monitor
 ```
 
 **Then you also can use keyboard or joystick as you control TurtleBot in simulation to control real TurtleBot**

--- a/workshop/source/_source/navigation/index.rst
+++ b/workshop/source/_source/navigation/index.rst
@@ -4,6 +4,6 @@ ROS 2 Navigation
 .. toctree::
    :maxdepth: 1
 
-   TurtleBot <ROS2-Turtlebot>
+   TurtleBot 3 <ROS2-Turtlebot>
    Cartographer <ROS2-Cartographer>
    Navigation <ROS2-Navigation>

--- a/workshop/source/_source/navigation/index.rst
+++ b/workshop/source/_source/navigation/index.rst
@@ -1,0 +1,9 @@
+ROS 2 Navigation
+================
+
+.. toctree::
+   :maxdepth: 1
+
+   TurtleBot <ROS2-Turtlebot>
+   Cartographer <ROS2-Cartographer>
+   Navigation <ROS2-Navigation>

--- a/workshop/source/conf.py
+++ b/workshop/source/conf.py
@@ -67,7 +67,7 @@ html_theme_options = {
     'style_external_links': False,
     'collapse_navigation': True,
     'sticky_navigation': False,
-    'navigation_depth': 4,
+    'navigation_depth': 2,
     'includehidden': True,
     'titles_only': False,
 }

--- a/workshop/source/index.rst
+++ b/workshop/source/index.rst
@@ -1,57 +1,11 @@
-.. ROS 2 workshop index page, created by
-   sphinx-quickstart on Fri Feb  5 13:33:39 2021.
-   Each new `Session` should contain the root [toctree](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-toctree) directive.
+Welcome to the ROS 2 workshop!
+==============================
 
-Welcome to ROS 2 workshop!
-==========================
-
-Session 1 - ROS 2 Concepts and Fundamentals
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
-   Exercise 1.0 - ROS-2-Filesystem <_source/basics/ROS2-Filesystem.md>
-   Exercise 1.1 - ROS-2-Simple-Publisher-Subscriber <_source/basics/ROS2-Simple-Publisher-Subscriber.md>
-   Exercise 1.2 - ROS-2-Turtlesim <_source/basics/ROS2-Turtlesim.md>
-
-Session 2 - Ros2 Concepts and Fundementals Advanced(Optional)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. toctree::
-   :maxdepth: 1
-
-Session 3 - ROS2 Navigation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. toctree::
-   :maxdepth: 1
-
-   Exercise 3.1 - ROS2-TF2 <_source/navigation/ROS2-TF2.md>
-   Exercise 3.2 - ROS2-Turtlebot <_source/navigation/ROS2-Turtlebot.md>
-   Exercise 3.3 - ROS2-Cartographer <_source/navigation/ROS2-Cartographer.md>
-   Exercise 3.4 - ROS2-Navigation <_source/navigation/ROS2-Navigation.md>
-
-Session 4 - ROS2 Manipulation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. toctree::
-   :maxdepth: 1
-
-   Exercise 4 - ROS2-Moveit2-Setup-Assisitance <_source/manipulation/setup_assistance.md>
-
-Session 5 - ROS2 URDF
-~~~~~~~~~~~~~~~~~~~~~~
-.. toctree::
-   :maxdepth: 1
-
-   ROS2 URDF_Introduction <_source/urdf/introduction.md>
-   Exercise 5 - Ros2-Cartesian Robot <_source/urdf/cartesian_tutorial.md>
-
-Session 6 - ROS2 Control
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. toctree::
-   :maxdepth: 1
-
-   Exercise 6.1 - ROS2-Control-Example-1 <_source/control/01_Example.md>
-   Exercise 6.2 - ROS2-Control-Example-2 <_source/control/02_Example.md>
-   Exercise 6.3 - ROS2-Control-Example-3 <_source/control/03_Example.md>
-   Exercise 6.4 - ROS2-Control-Example-4 <_source/control/04_Example.md>
-   Exercise 6.5 - ROS2-Control-Example-5 <_source/control/05_Example.md>
-   Exercise 6.6 - ROS2-Control-Example-6 <_source/control/06_Example.md>
+   Getting started <_source/getting_started/index>
+   ROS 2 basics <_source/basics/index>
+   ROS 2 Navigation <_source/navigation/index>
+   ROS 2 Manipulation <_source/manipulation/index>
+   ROS 2 control <_source/control/index>


### PR DESCRIPTION
- Reorganized sidebar sections
- New prerequisites, Linux, Terminator, networking, Git/vcstool, and Docker pages
- Clearer ROS 2 Control and TurtleBot 3 labels
- Removal of $ shell prompt markers from commands