### PR TITLE
Expand ROS 2 basics with a Python service tutorial

### DIFF
--- a/workshop/source/_source/basics/ROS2-Simple-Publisher-Subscriber.md
+++ b/workshop/source/_source/basics/ROS2-Simple-Publisher-Subscriber.md
@@ -1,5 +1,5 @@
 
-# Understanding ROS 2 nodes with a simple Publisher - Subscriber pair
+# Simple Publisher - Subscriber pair
 **Based on the [ROS 2 Tutorials](https://docs.ros.org/en/foxy/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber.html)**
 
 ## Introduction
@@ -391,3 +391,128 @@ Similarly as the previous two cases, we need to declare a third executor that po
 
 Build the workspace and run this new executable, whose name in this case is `composed`.
 You will observe that indeed both the publisher and subscriber are running from within the same executable.
+
+
+## 5 Exercise: Use a different message type
+
+The publisher and subscriber in this tutorial use `std_msgs/msg/String`. Your
+task is to write another publisher and subscriber that communicate using a
+different ROS 2 message type.
+
+Browse the message packages in
+[ros2/common_interfaces](https://github.com/ros2/common_interfaces) and select
+a message type other than `std_msgs/msg/String).
+
+Beginner-friendly choices include:
+
+- `geometry_msgs/msg/Point`
+- `geometry_msgs/msg/Twist`
+- `sensor_msgs/msg/Temperature`
+
+### 5.1 Inspect the interface
+
+Before writing code, inspect the fields of the selected message. For example:
+
+```bash
+ros2 interface show geometry_msgs/msg/Point
+```
+
+Replace `geometry_msgs/msg/Point` with your selected interface. Identify:
+
+1. the Python package and class that must be imported
+2. the fields that the publisher must populate
+3. the fields that the subscriber should display
+
+### 5.2 Create the nodes
+
+Inside the `wshop_nodes/wshop_nodes` Python module, create:
+
+```text
+custom_publisher.py
+custom_subscriber.py
+```
+
+Use the publisher and subscriber from this tutorial as a starting point, but
+make the following changes:
+
+- import the selected message class
+- use that class when creating the publisher and subscription
+- publish on a new topic such as `custom_topic`
+- populate the message with valid, changing values
+- log meaningful fields when the subscriber receives a message
+
+The publisher and subscriber must use exactly the same message type and topic
+name.
+
+### 5.3 Add the dependency
+
+Add the package containing your selected message to `package.xml`. For
+example, when using `geometry_msgs/msg/Point` or
+`geometry_msgs/msg/Twist`:
+
+```xml
+<exec_depend>geometry_msgs</exec_depend>
+```
+
+When using `sensor_msgs/msg/Temperature`:
+
+```xml
+<exec_depend>sensor_msgs</exec_depend>
+```
+
+Use the package name from the part before `/msg/` in the interface name.
+
+### 5.4 Register the executables
+
+Add entry points for both new nodes to the `console_scripts` list in
+`setup.py`. For example:
+
+```python
+'custom_talker = wshop_nodes.custom_publisher:main',
+'custom_listener = wshop_nodes.custom_subscriber:main',
+```
+
+### 5.5 Build and run
+
+From the root of the workspace:
+
+```bash
+rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
+colcon build --symlink-install --packages-select wshop_nodes
+source install/setup.bash
+```
+
+Run the publisher:
+
+```bash
+ros2 run wshop_nodes custom_talker
+```
+
+In another terminal, source ROS 2 and the workspace, then run the subscriber:
+
+```bash
+source /opt/ros/$ROS_DISTRO/setup.bash
+cd ~/dev_ws
+source install/setup.bash
+ros2 run wshop_nodes custom_listener
+```
+
+### 5.6 Verify the result
+
+While both nodes are running, use a third terminal to inspect the topic:
+
+```bash
+ros2 topic info /custom_topic --verbose
+ros2 topic echo /custom_topic
+```
+
+Check that:
+
+- the topic uses the message type you selected
+- one publisher and one subscriber are connected
+- the published field values change over time
+- the subscriber prints the expected values
+
+As an additional test, stop your publisher and publish one message manually
+with `ros2 topic pub --once`. Use `ros2 interface show` to determine the
+correct YAML fields for your selected message.

--- a/workshop/source/_source/basics/ROS2-Simple-Service.md
+++ b/workshop/source/_source/basics/ROS2-Simple-Service.md
@@ -1,0 +1,382 @@
+# Simple Service in Python
+
+## Introduction
+
+ROS 2 services implement request-response communication between nodes. A
+client sends a request, a server processes it, and the server returns one
+response. Services are useful for operations that should be performed on
+demand rather than continuously.
+
+This exercise creates a Python service server and an asynchronous client for
+the `example_interfaces/srv/AddTwoInts` service. The request contains two
+integers:
+
+```text
+int64 a
+int64 b
+---
+int64 sum
+```
+
+The fields above `---` belong to the request. The field below it belongs to
+the response.
+
+## 1. Create the package
+
+Source ROS 2 and create a workspace if one does not already exist:
+
+```bash
+source /opt/ros/$ROS_DISTRO/setup.bash
+mkdir -p ~/dev_ws/src
+cd ~/dev_ws/src
+```
+
+Create an `ament_python` package:
+
+```bash
+ros2 pkg create --build-type ament_python --license Apache-2.0 \
+  py_srvcli --dependencies rclpy example_interfaces
+```
+
+The `--dependencies` option adds `rclpy` and `example_interfaces` to
+`package.xml`.
+
+The generated package has this structure:
+
+```text
+py_srvcli/
+├── package.xml
+├── py_srvcli/
+│   └── __init__.py
+├── resource/
+│   └── py_srvcli
+├── setup.cfg
+└── setup.py
+```
+
+## 2. Write the server
+
+Create `service.py` in the Python module directory:
+
+```bash
+cd ~/dev_ws/src/py_srvcli/py_srvcli
+touch service.py
+```
+
+Add the following code:
+
+```python
+from example_interfaces.srv import AddTwoInts
+import rclpy
+from rclpy.node import Node
+
+
+class MinimalService(Node):
+
+    def __init__(self):
+        super().__init__('minimal_service')
+
+        self.srv = self.create_service(
+            AddTwoInts,
+            'add_two_ints',
+            self.add_two_ints_callback
+        )
+
+    def add_two_ints_callback(self, request, response):
+        response.sum = request.a + request.b
+
+        self.get_logger().info(
+            f'Incoming request: {request.a} + {request.b}'
+        )
+
+        return response
+
+
+def main():
+    rclpy.init()
+
+    minimal_service = MinimalService()
+
+    rclpy.spin(minimal_service)
+
+    minimal_service.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()
+```
+
+### 2.1 Create the service
+
+```python
+self.srv = self.create_service(
+    AddTwoInts,
+    'add_two_ints',
+    self.add_two_ints_callback
+)
+```
+
+`create_service()` specifies:
+
+1. the service type: `AddTwoInts`
+2. the service name: `add_two_ints`
+3. the callback that handles incoming requests
+
+The server stores the returned service object in `self.srv` so that it remains
+available for the lifetime of the node.
+
+### 2.2 Process the request
+
+```python
+def add_two_ints_callback(self, request, response):
+    response.sum = request.a + request.b
+
+    self.get_logger().info(
+        f'Incoming request: {request.a} + {request.b}'
+    )
+
+    return response
+```
+
+The callback receives an `AddTwoInts.Request` and an empty
+`AddTwoInts.Response`. It adds `request.a` and `request.b`, stores the
+result in `response.sum`, and returns the completed response to the client.
+
+### 2.3 Spin the server
+
+```python
+rclpy.spin(minimal_service)
+```
+
+The server must keep spinning so that its executor can receive requests and
+invoke `add_two_ints_callback`. Stop it with `Ctrl+C`.
+
+## 3. Write the client
+
+Create `client.py` in the Python module directory:
+
+```bash
+cd ~/dev_ws/src/py_srvcli/py_srvcli
+touch client.py
+```
+
+Add the following code:
+
+```python
+import sys
+
+from example_interfaces.srv import AddTwoInts
+import rclpy
+from rclpy.node import Node
+
+
+class MinimalClientAsync(Node):
+
+    def __init__(self):
+        super().__init__('minimal_client_async')
+
+        self.cli = self.create_client(AddTwoInts, 'add_two_ints')
+
+        while not self.cli.wait_for_service(timeout_sec=1.0):
+            self.get_logger().info(
+                'service not available, waiting again...'
+            )
+
+    def send_request(self, a, b):
+        req = AddTwoInts.Request()
+        req.a = a
+        req.b = b
+
+        future = self.cli.call_async(req)
+        future.add_done_callback(self.response_callback)
+
+    def response_callback(self, future):
+        try:
+            response = future.result()
+            self.get_logger().info(
+                f'Result of add_two_ints: {response.sum}'
+            )
+        except Exception as e:
+            self.get_logger().error(
+                f'Service call failed: {e}'
+            )
+
+
+def main():
+    rclpy.init()
+
+    minimal_client = MinimalClientAsync()
+
+    a = int(sys.argv[1])
+    b = int(sys.argv[2])
+
+    minimal_client.send_request(a, b)
+
+    rclpy.spin(minimal_client)
+
+    minimal_client.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()
+```
+
+## 4. Understand the client
+
+### 4.1 Create the node and client
+
+```python
+class MinimalClientAsync(Node):
+
+    def __init__(self):
+        super().__init__('minimal_client_async')
+
+        self.cli = self.create_client(AddTwoInts, 'add_two_ints')
+```
+
+`MinimalClientAsync` inherits from `Node`. The call to `create_client`
+specifies:
+
+1. the service type: `AddTwoInts`
+2. the service name: `add_two_ints`
+
+Both must match the server.
+
+### 4.2 Wait for the server
+
+```python
+while not self.cli.wait_for_service(timeout_sec=1.0):
+    self.get_logger().info(
+        'service not available, waiting again...'
+    )
+```
+
+The client checks once per second until a matching service is available. This
+prevents it from sending a request before the server is ready.
+
+### 4.3 Send an asynchronous request
+
+```python
+req = AddTwoInts.Request()
+req.a = a
+req.b = b
+
+future = self.cli.call_async(req)
+future.add_done_callback(self.response_callback)
+```
+
+`call_async()` returns immediately with a future representing the pending
+result. Registering `response_callback` tells ROS 2 what to execute when that
+future finishes.
+
+### 4.4 Process the response
+
+```python
+def response_callback(self, future):
+    try:
+        response = future.result()
+        self.get_logger().info(
+            f'Result of add_two_ints: {response.sum}'
+        )
+    except Exception as e:
+        self.get_logger().error(
+            f'Service call failed: {e}'
+        )
+```
+
+`future.result()` returns the response or raises an exception if the request
+failed.
+
+### 4.5 Spin the node
+
+```python
+rclpy.spin(minimal_client)
+```
+
+Spinning lets the executor process the response callback. This client continues
+spinning after it prints the result; stop it with `Ctrl+C`.
+
+The program expects exactly two integer command-line arguments. Running it
+without both arguments, or with non-integer values, causes an error.
+
+## 5. Register the executables
+
+Open `~/dev_ws/src/py_srvcli/setup.py` and add entry points for both nodes:
+
+```python
+entry_points={
+    'console_scripts': [
+        'service = py_srvcli.service:main',
+        'client = py_srvcli.client:main',
+    ],
+},
+```
+
+The name before `=` is the executable passed to `ros2 run`. The value after
+`=` identifies the Python module and its `main` function.
+
+## 6. Build the package
+
+From the workspace root, install dependencies and build:
+
+```bash
+cd ~/dev_ws
+rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
+colcon build --symlink-install --packages-select py_srvcli
+source install/setup.bash
+```
+
+## 7. Run the server and client
+
+In the first terminal, source ROS 2 and the workspace, then start the server:
+
+```bash
+source /opt/ros/$ROS_DISTRO/setup.bash
+cd ~/dev_ws
+source install/setup.bash
+ros2 run py_srvcli service
+```
+
+In a second terminal, source ROS 2 and the workspace:
+
+```bash
+source /opt/ros/$ROS_DISTRO/setup.bash
+cd ~/dev_ws
+source install/setup.bash
+```
+
+Run the client with two integers:
+
+```bash
+ros2 run py_srvcli client 2 3
+```
+
+The client prints:
+
+```text
+[INFO] [minimal_client_async]: Result of add_two_ints: 5
+```
+
+Press `Ctrl+C` to stop the client after receiving the response. Use
+`Ctrl+C` in the first terminal to stop the server.
+
+## 8. Inspect the service
+
+With the server running, inspect the available service and its interface:
+
+```bash
+ros2 service list
+ros2 service type /add_two_ints
+ros2 interface show example_interfaces/srv/AddTwoInts
+```
+
+The service can also be tested directly from the command line:
+
+```bash
+ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts \
+  "{a: 2, b: 3}"
+```
+
+The response contains `sum: 5`.

--- a/workshop/source/_source/basics/index.rst
+++ b/workshop/source/_source/basics/index.rst
@@ -4,7 +4,8 @@ ROS 2 basics
 .. toctree::
    :maxdepth: 1
 
-   File system <ROS2-Filesystem>
-   Publisher and subscriber <ROS2-Simple-Publisher-Subscriber>
-   Turtlesim <ROS2-Turtlesim>
-   TF2 <../navigation/ROS2-TF2>
+   2.1 File system <ROS2-Filesystem>
+   2.2 Publisher and subscriber <ROS2-Simple-Publisher-Subscriber>
+   2.3 Simple Service in Python <ROS2-Simple-Service>
+   2.4 Turtlesim <ROS2-Turtlesim>
+   2.5 TF2 <../navigation/ROS2-TF2>

--- a/workshop/source/_source/control/index.rst
+++ b/workshop/source/_source/control/index.rst
@@ -4,9 +4,9 @@ ROS 2 control
 .. toctree::
    :maxdepth: 1
 
-   RRBot <01_Example>
-   DiffBot <02_Example>
-   Robots with multiple interfaces <03_Example>
-   Industrial robot with an externally connected sensor <04_Example>
-   WBot mobile manipulator <05_Example>
-   Tricycle robot setup <06_Example>
+   5.1 RRBot <01_Example>
+   5.2 DiffBot <02_Example>
+   5.3 Robots with multiple interfaces <03_Example>
+   5.4 Industrial robot with an externally connected sensor <04_Example>
+   5.5 WBot mobile manipulator <05_Example>
+   5.6 Tricycle robot setup <06_Example>

--- a/workshop/source/_source/getting_started/index.rst
+++ b/workshop/source/_source/getting_started/index.rst
@@ -7,9 +7,9 @@ throughout the workshop.
 .. toctree::
    :maxdepth: 1
 
-   Prerequisites <prerequisites>
-   Linux and terminal basics <linux_and_terminal>
-   Terminator <terminator>
-   Networking basics <networking>
-   Git and vcstool <git_and_vcstool>
-   Docker basics (optional) <docker>
+   1.1 Prerequisites <prerequisites>
+   1.2 Linux and terminal basics <linux_and_terminal>
+   1.3 Terminator <terminator>
+   1.4 Networking basics <networking>
+   1.5 Git and vcstool <git_and_vcstool>
+   1.6 Docker basics (optional) <docker>

--- a/workshop/source/_source/manipulation/index.rst
+++ b/workshop/source/_source/manipulation/index.rst
@@ -4,6 +4,6 @@ ROS 2 Manipulation
 .. toctree::
    :maxdepth: 1
 
-   MoveIt Setup Assistant <setup_assistance>
-   URDF introduction <../urdf/introduction>
-   Cartesian robot <../urdf/cartesian_tutorial>
+   4.1 MoveIt Setup Assistant <setup_assistance>
+   4.2 URDF introduction <../urdf/introduction>
+   4.3 Cartesian robot <../urdf/cartesian_tutorial>

--- a/workshop/source/_source/navigation/index.rst
+++ b/workshop/source/_source/navigation/index.rst
@@ -4,6 +4,6 @@ ROS 2 Navigation
 .. toctree::
    :maxdepth: 1
 
-   TurtleBot 3 <ROS2-Turtlebot>
-   Cartographer <ROS2-Cartographer>
-   Navigation <ROS2-Navigation>
+   3.1 TurtleBot 3 <ROS2-Turtlebot>
+   3.2 Cartographer <ROS2-Cartographer>
+   3.3 Navigation <ROS2-Navigation>

--- a/workshop/source/index.rst
+++ b/workshop/source/index.rst
@@ -4,8 +4,8 @@ Welcome to the ROS 2 workshop!
 .. toctree::
    :maxdepth: 2
 
-   Getting started <_source/getting_started/index>
-   ROS 2 basics <_source/basics/index>
-   ROS 2 Navigation <_source/navigation/index>
-   ROS 2 Manipulation <_source/manipulation/index>
-   ROS 2 control <_source/control/index>
+   1. Getting Started <_source/getting_started/index>
+   2. ROS 2 Basics <_source/basics/index>
+   3. ROS 2 Navigation <_source/navigation/index>
+   4. ROS 2 Manipulation <_source/manipulation/index>
+   5. ROS 2 Control <_source/control/index>


### PR DESCRIPTION
## Summary

- Number the workshop’s main sections and sidebar entries.
- Add a Python `AddTwoInts` service server and asynchronous client tutorial.
- Add a publisher/subscriber exercise using alternative message types from `common_interfaces`.
- Renumber Turtlesim and TF2 after the new service tutorial.
